### PR TITLE
Logo fix for SafemoonTon

### DIFF
--- a/jettons/safet.yaml
+++ b/jettons/safet.yaml
@@ -1,6 +1,6 @@
 name: SafemoonTon
 description: SafemoonTon is not just a meme project - it's a movement. We're building an ecosystem that will make a lasting impact on TON Blockchain and the crypto industry at large.
-image: "https://safemoonton.com/wp-content/uploads/2024/03/cropped-cropped-cropped-Untitled_design__13_-removebg-preview.png"
+image: "https://safemoonton.com/wp-content/uploads/2024/03/safet_logo.png"
 address: EQBgLw3RLkELgOJUU1oHtHzwkoTdb4RgfT8IgTG6k_iLneEc
 symbol: SAFET
 max_supply: 1000000000000


### PR DESCRIPTION
We found out that the TON logo on the logo we submitted is dark and more suitable for light mode. With more users on the default dark mode, we want this logo with the white TON logo instead.

Please make sure you change the original ones `.yaml` fiels in directories `accounts/`, `collections/` or  `jettons/` and do not touch automatically generated .json files in the repository root.


Пожалуйста, убедитесь, что вы изменяете исходные `.yaml` файлы в директориях  `accounts/`, `collections/` или  `jettons/` и не трогаете автоматически сгенерированные файлы `.json` в корне репозитория.