### PR TITLE
Adding DOGWIFHOOD to TonKeeper

### DIFF
--- a/jettons/WIF.yaml
+++ b/jettons/WIF.yaml
@@ -1,0 +1,11 @@
+name: DOGWIFHOOD
+description: Pavel Durov's Dog Wif Hood
+image: "https://wifhood.dog/img/logo.png"
+address: EQAuco5ZEPgB19fSTo7EmtLTJysrKxbu6M_XOFDwWQiNjCsQ
+symbol: WIF
+max_supply: 998920173
+websites:
+  - "https://wifhood.dog"
+social:
+  - "https://t.me/dogwifhood_TON"
+  - "https://twitter.com/dogwifhoodTON"


### PR DESCRIPTION
Hello,

Please consider adding DOGWIFHOOD to the list of supported/verified jettons on tonkeeper! We've already been listed on [CoinGecko](https://www.coingecko.com/en/coins/dogwifhood) and we currently have more than 1300 holders. 
Would be great if you can make DOGWIFHOOD a trustworthy token on TonKeeper

Thank you!