### PR TITLE
Adding 2Miners.com payouts address

### DIFF
--- a/accounts/infrastructure.yaml
+++ b/accounts/infrastructure.yaml
@@ -30,3 +30,5 @@
   name: "battery.ton"
 - address: "UQByUegyggQM_SOHz2d7KGT38CFyD6BAzaVDqRlBGUQs6grh"
   name: "Tonkeeper battery refunds"
+- address: "UQC-4p-7hC-cAt7RvD1qZQrnp1BUU1ba5CYMiQEAQlOu6HOJ"
+  name: "2Miners.com Mining Pool (TON Payouts)"


### PR DESCRIPTION
2Miners.com allows their miners to anonymously provide a TON address for many altcoins it supports and the mining rewards will be automatically converted to TON and paid out from the address `UQC-4p-7hC-cAt7RvD1qZQrnp1BUU1ba5CYMiQEAQlOu6HOJ`.