### PR TITLE
Add DRAGO token

### DIFF
--- a/jettons/drago.yaml
+++ b/jettons/drago.yaml
@@ -1,0 +1,9 @@
+name: Triggered DRAGO
+description: Community Takeover Token - DRAGO captures your inner dragon’s fury whenever the market pumps. Laser eyes fuel those chaotic FOMO moments when your inner beast can’t help but scream: BUY buy BUY. Part of The Community Squad.
+image: "https://s3.blum.codes/7f146e60-a46b-4d16-a08a-61a2168e6c34/6ee85f24-f91e-4477-a28a-bbd96d27f91f"
+address: 0:19cef63ab52ab6220851f12de65e0737f3b5a5eb25f9e0c550767149d841d0f7
+symbol: DRAGO
+social:
+  - "https://t.me/Drago_CTO"
+  - "https://x.com/Drago_CTO"
+  - "https://t.me/hubz_app_bot?start=subscribe-674657ac1aea8b67503a009f"

--- a/jettons/mulb.yaml
+++ b/jettons/mulb.yaml
@@ -1,9 +1,0 @@
-name: mulB
-description: mulB is Blum, but backwards. Part of The Community Squad.
-symbol: MULB
-image: "https://s3.blum.codes/7cfe0d1a-02aa-49dc-b251-ac6db1c4cfb4/1884cfb8-4c0f-426a-8837-917141f39952"
-address: 0:8e0d5a54955d3b016b0ed57f4b27f4e03dc1cf72a5f7ced5f103297ac13327b2
-social:
-  - "https://t.me/mulB_cto"
-  - "https://x.com/mulB_cto"
-  - "https://t.me/hubz_app_bot?start=subscribe-674657ac1aea8b67503a009f"

--- a/jettons/mulb.yaml
+++ b/jettons/mulb.yaml
@@ -1,0 +1,9 @@
+name: mulB
+description: mulB is Blum, but backwards. Part of The Community Squad.
+symbol: MULB
+image: "https://s3.blum.codes/7cfe0d1a-02aa-49dc-b251-ac6db1c4cfb4/1884cfb8-4c0f-426a-8837-917141f39952"
+address: 0:8e0d5a54955d3b016b0ed57f4b27f4e03dc1cf72a5f7ced5f103297ac13327b2
+social:
+  - "https://t.me/mulB_cto"
+  - "https://x.com/mulB_cto"
+  - "https://t.me/hubz_app_bot?start=subscribe-674657ac1aea8b67503a009f"


### PR DESCRIPTION
$DRAGO token details:

name: Triggered DRAGO
description: Community Takeover Token - DRAGO captures your inner dragon’s fury whenever the market pumps. Laser eyes fuel those chaotic FOMO moments when your inner beast can’t help but scream: BUY buy BUY. Part of The Community Squad.
image: "https://s3.blum.codes/7f146e60-a46b-4d16-a08a-61a2168e6c34/6ee85f24-f91e-4477-a28a-bbd96d27f91f"
address: 0:19cef63ab52ab6220851f12de65e0737f3b5a5eb25f9e0c550767149d841d0f7
symbol: DRAGO
social:
  - "https://t.me/Drago_CTO"
  - "https://x.com/Drago_CTO"
  - "https://t.me/hubz_app_bot?start=subscribe-674657ac1aea8b67503a009f"