### PR TITLE
Added metadata for the official Nivarium token ($NVRM) including description, symbol, and social links.

### DIFF
--- a/jettons/NIVARIUM.yaml
+++ b/jettons/NIVARIUM.yaml
@@ -1,0 +1,10 @@
+name: NIvarium
+description: The official Nivarium token ($NVRM) is built on the TON blockchain
+address: EQC3kcBB-a_u4t2C5srX1x6ycUPsY7jpsqzdhRnkurMZWUka
+symbol: NVRM
+image: "https://nivarium.online/public/NivariumCoin.png"
+websites:
+  - "https://nivarium.online"
+social:
+  - "https://t.me/nivarium_official"
+  - "https://x.com/nivarium"

--- a/jettons/NIVARIUM.yaml
+++ b/jettons/NIVARIUM.yaml
@@ -1,4 +1,4 @@
-name: NIvarium
+name: Nivarium
 description: The official Nivarium token ($NVRM) is built on the TON blockchain
 address: EQC3kcBB-a_u4t2C5srX1x6ycUPsY7jpsqzdhRnkurMZWUka
 symbol: NVRM


### PR DESCRIPTION
name: Nivarium
description: The official Nivarium token ($NVRM) is built on the TON blockchain
address: EQC3kcBB-a_u4t2C5srX1x6ycUPsY7jpsqzdhRnkurMZWUka
symbol: NVRM
image: "https://nivarium.online/public/NivariumCoin.png"
websites:
  - "https://nivarium.online"
social:
  - "https://t.me/nivarium_official"
  - "https://x.com/nivarium"