### PR TITLE
E=ME²

### DIFF
--- a/jettons/E=ME²
+++ b/jettons/E=ME²
@@ -1,0 +1,6 @@
+  address": "0:f92a541fb17b07806b29b21f7405c06557106da847c5823e2d2bfd7e0abcf418",
+  "name": "E=ME²",
+  "symbol": "E=ME²",
+  "decimals": "9",
+  "image": "https://cache.tonapi.io/imgproxy/42HRGFcS9bcZ8D6Mna4Hz_5C5CakjflkJp5xmtJuW5c/rs:fill:200:200:1/g:no/aHR0cHM6Ly9tZWRpYS50ZW5vci5jb20vMmFTV1R3bWxydlVBQUFBaS9laW5zdGVpbi5naWY.webp",
+  "description": "Einstein meme solved an equation of his own, he first realized that E=EM², this happened when he took himself under the radical!!!  The answer is clear: √EinsteinMEME ≈ E=ME²"


### PR DESCRIPTION
Einstein meme solved an equation of his own, he first realized that E=EM², this happened when he took himself under the radical!!!  The answer is clear: √EinsteinMEME≈ E=ME²

Please make sure you change the original .yaml fields in the accounts/, Collections/ or jettons/ directories and leave the auto-generated .json files in the repository root alone. Also please make sure that you do not use ton.api links in your pull request.
Example pull request:

```yaml
  "address": "0:f92a541fb17b07806b29b21f7405c06557106da847c5823e2d2bfd7e0abcf418",
  "name": "E=ME²",
  "symbol": "E=ME²",
  "decimals": "9",
  "image": "https://cache.tonapi.io/imgproxy/42HRGFcS9bcZ8D6Mna4Hz_5C5CakjflkJp5xmtJuW5c/rs:fill:200:200:1/g:no/aHR0cHM6Ly9tZWRpYS50ZW5vci5jb20vMmFTV1R3bWxydlVBQUFBaS9laW5zdGVpbi5naWY.webp",
  "description": "Einstein meme solved an equation of his own, he first realized that E=EM², this happened when he took himself under the radical!!!  The answer is clear: √EinsteinMEME ≈ E=ME²"
```


