### PR TITLE
Add Entangle Token to TON

### DIFF
--- a/jettons/Entangle.yaml
+++ b/jettons/Entangle.yaml
@@ -1,0 +1,10 @@
+name: NGL Token
+description: entangle.fi is the programmable interoperability layer, connecting blockchains, data, and the real world, unlocking limitless assets and applications
+image: "https://i.postimg.cc/BnCbVLZ7/a-HR0c-HM6-Ly9j-YWxs-ZGF0-YWNvbn-Zlcn-Rlci52-ZXJj-ZWwu-YXBw-L2xv-Z28ud2-Vic-A.webp"
+address: 0:2665c46c6b2b453a594f656efb18294a6fb1ac27c69e93f2824877a8d6782971
+symbol: NGL
+websites:
+  - "https://entangle.fi"
+social:
+  - "https://t.me/entangle_community"
+  - "https://x.com/Entanglefi"


### PR DESCRIPTION
name: NGL Token
description: entangle.fi is the programmable interoperability layer, connecting blockchains, data, and the real world, unlocking limitless assets and applications
image: "https://i.postimg.cc/BnCbVLZ7/a-HR0c-HM6-Ly9j-YWxs-ZGF0-YWNvbn-Zlcn-Rlci52-ZXJj-ZWwu-YXBw-L2xv-Z28ud2-Vic-A.webp"
address: 0:2665c46c6b2b453a594f656efb18294a6fb1ac27c69e93f2824877a8d6782971
symbol: NGL
websites:
  - "https://entangle.fi"
social:
  - "https://t.me/entangle_community"
  - "https://x.com/Entanglefi"