### PR TITLE
adding ARC jetton

### DIFF
--- a/jettons/ARC.yaml
+++ b/jettons/ARC.yaml
@@ -1,6 +1,6 @@
 name: ARC jetton
 description: ARC is the utility token released by the ecosystem Architec.ton, based on the Telegram ecosystem. ARC is the main token used inside games and the projects in Architec.ton ecosystem.
-image: "https://cache.tonapi.io/imgproxy/cOMlJuViiVXDCkAghnyNj7plX8pAZ9pv3WhklvebpTY/rs:fill:200:200:1/g:no/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3RvbmtlZXBlci9vcGVudG9uYXBpL21hc3Rlci9wa2cvcmVmZXJlbmNlcy9tZWRpYS90b2tlbl9wbGFjZWhvbGRlci5wbmc.web"
+image: "https://raw.githubusercontent.com/Architec-Ton/banktoken/refs/heads/main/docs/ARC.png"
 address: EQBXRdZTk5P49mL0nOYfDR1VR33N3sPUgB7PNQMaj6DhxOJH
 symbol: ARC
 websites:

--- a/jettons/ARC.yaml
+++ b/jettons/ARC.yaml
@@ -1,5 +1,5 @@
 name: ARC jetton
-description: ARC is the utility token released by the ecosystem Architec.ton, based on the Telegram ecosystem. ARC is the main token used inside games and the projects in Architec.ton ecosystem.
+description: ARC is the utility token released by the ecosystem Architec.ton, based on the Telegram ecosystem. ARC is the main token used inside apps (games etc.) in Architec.ton ecosystem.
 image: "https://raw.githubusercontent.com/Architec-Ton/banktoken/refs/heads/main/docs/ARC.png"
 address: EQBXRdZTk5P49mL0nOYfDR1VR33N3sPUgB7PNQMaj6DhxOJH
 symbol: ARC

--- a/jettons/ARC.yaml
+++ b/jettons/ARC.yaml
@@ -1,0 +1,12 @@
+name: ARC jetton
+description: ARC is the utility token released by the ecosystem Architec.ton, based on the Telegram ecosystem. ARC is the main token used inside games and the projects in Architec.ton ecosystem.
+image: "https://cache.tonapi.io/imgproxy/cOMlJuViiVXDCkAghnyNj7plX8pAZ9pv3WhklvebpTY/rs:fill:200:200:1/g:no/aHR0cHM6Ly9yYXcuZ2l0aHVidXNlcmNvbnRlbnQuY29tL3RvbmtlZXBlci9vcGVudG9uYXBpL21hc3Rlci9wa2cvcmVmZXJlbmNlcy9tZWRpYS90b2tlbl9wbGFjZWhvbGRlci5wbmc.web"
+address: EQBXRdZTk5P49mL0nOYfDR1VR33N3sPUgB7PNQMaj6DhxOJH
+symbol: ARC
+websites:
+  - "https://architecton.tech"
+  - "https://architec.ton"
+social:
+  - "https://t.me/architecton_tech"
+  - "https:///t.me/architecton_eu"
+  - "https://x.com/architec_ton"


### PR DESCRIPTION
Hey, team!
Add, please, to wallet  ARC jetton
ARC is the utility token released by the ecosystem Architec.ton, based on the Telegram ecosystem. ARC is the main token used inside games and the projects in Architec.ton ecosystem