### PR TITLE
Add Vending Coin (VNDG) details

### DIFF
--- a/jettons/VNDG.yaml
+++ b/jettons/VNDG.yaml
@@ -1,0 +1,12 @@
+name: Vending Coin
+description: Vending Coin (abbreviated as $VNDG) is a multipurpose token on the TON blockchain.
+image: "https://vending-coin.github.io/Vending%20Coin%20logo.png"
+address: EQBMQVUuvX3nEninvViwF4d1C1tCmkV6kaqXOVaKpmeQ2O-7
+symbol: VNDG
+decimals: 3
+websites:
+  - "https://vndg.world/"
+social:
+  - "https://t.me/VNDG_COIN"
+  - "https://x.com/VNDG_COIN"
+  - "https://www.youtube.com/@VNDG_COIN"


### PR DESCRIPTION
Added Vending Coin (VNDG) details to the jettons directory. This includes the token's name, description, image, address, symbol, website, and social links.
