### PR TITLE
Create 44AD.yaml

### DIFF
--- a/jettons/44AD.yaml
+++ b/jettons/44AD.yaml
@@ -1,0 +1,8 @@
+name: Chuvash Private Army of Drones
+description: This token confirms ownership of shares of the Private Chuvash Army of Drones. The owner of more than 200 tokens automatically enters the Board of Directors
+image: "https://raw.githubusercontent.com/ChuvashiaBulgaria/44ad/refs/heads/main/44AD.jpg"
+address: "EQA3i1rmVQyyVtZaorilwcs3ro-fVdw03MBZZzOD-8QNILgX"
+symbol: 44AD
+decimals: 9
+social:
+  - "https://t.me/Chuvash_Drones_Army"


### PR DESCRIPTION
name: Chuvash Private Army of Drones
description: This token confirms ownership of shares of the Private Chuvash Army of Drones. The owner of more than 200 tokens automatically enters the Board of Directors
image: "https://raw.githubusercontent.com/ChuvashiaBulgaria/44ad/refs/heads/main/44AD.jpg"
address: "EQA3i1rmVQyyVtZaorilwcs3ro-fVdw03MBZZzOD-8QNILgX"
symbol: 44AD
decimals: 9
social:
  - "https://t.me/Chuvash_Drones_Army"