### PR TITLE
Create Cuban Peso (CUPT)

### DIFF
--- a/jettons/CUPT.yaml
+++ b/jettons/CUPT.yaml
@@ -1,0 +1,3 @@
+- address: "0:4e784d202f454a0ab5332ac908dada7220e8b003b567de216f1ef708b7d86866"
+  symbol: "CUPT"
+  name: "Cuban Peso"


### PR DESCRIPTION
```yaml
name: Cuban Peso
description: CUPT is the Cuban Peso pegged coin that provides payments in the QvaPay ecosystem.
image: https://qvpay.me/assets/CUPT/cupt256.png
address: EQBOeE0gL0VKCrUzKskI2tpyIOiwA7Vn3iFvHvcIt9hoZruE
symbol: CUPT
websites:
  - https://qvpay.me/coins/CUPT
social:
  - https://www.twitter.com/qvapay
```
