### PR TITLE
Add FLA token

### DIFF
--- a/jettons/FLA.yaml
+++ b/jettons/FLA.yaml
@@ -1,0 +1,10 @@
+name: Flash Jetton
+description: A utility AI token with mining rewards
+address: 0:3b559399d77431617ec53ffad70cd431d99b8463c62a1568bccb2d2f4346ff9d
+symbol: FLA
+websites:
+  - "tonsite://flashjet.ton/"
+social:
+  - "https://t.me/flashjetton"
+  - "https://telegra.ph/Flash-Jetton-Litepaper-v2-RU-02-03"
+  - "https://telegra.ph/Flash-Jetton-Litepaper-en-01-17"


### PR DESCRIPTION
Hello. Our project is designed in such a way that it does not have a website on the general Internet. The entire infrastructure of the project will be based in the Telegram and TON ecosystems. The tonsite://flashjet.ton/ domain will host a smart contract for mining tokens, but this will be a little later, after the completion of the Airdrop stage. At the moment, we are doing an Airdrop and conducting a referral program, and we would like to remove the "unverified token" status in the Tonkeeper wallet, since some users do not respond adequately to this status and we receive a lot of feedback from users in this regard, and therefore we receive slow community growth. Thanks for understanding.