### PR TITLE
Add GPTON token

### DIFF
--- a/jettons/GPTON.yaml
+++ b/jettons/GPTON.yaml
@@ -1,0 +1,10 @@
+name: GPTON
+description: Mineable token that can be used on gaming platform (https://gpton.co) | Play games, earn $ passively or actively with games
+image: "https://storage.ronin.co/spa_ylclqjgxpp9m50zk/1f1ebe07-fea5-4e8b-9f1d-b512b4816d36"
+address: EQB2ONl9nfzoGfeRFhvKTLX28MOD_nvT8cfI41-FylvNvvHm
+symbol: GPTON
+websites:
+  - "https://gpton.co"
+social:
+  - "https://t.me/gpton_games"
+  - "https://x.com/gpton_games"


### PR DESCRIPTION
Good afternoon. 

We are building a mini app game platform and have native token GPTON which users can exchange their game points for. 

The token can be found on Tonviewer [here](https://tonviewer.com/EQB2ONl9nfzoGfeRFhvKTLX28MOD_nvT8cfI41-FylvNvvHm).

The jetton has contract code that limits the max supply that can ever be minted to 1 billion.

The code for jetton can be seen [here](https://tonviewer.com/EQB2ONl9nfzoGfeRFhvKTLX28MOD_nvT8cfI41-FylvNvvHm?section=code).

Namely these parts are important:

<img width="1038" alt="image" src="https://github.com/user-attachments/assets/3731ce85-66e2-4ad2-b5ea-77f19a6facd9" />

Initial distribution of token is described on website: [gpton.co](https://gpton.co)

There is already an [active liquidity pool on Ston.fi](https://app.ston.fi/swap?chartVisible=true&chartInterval=1w&ft=TON&tt=EQB2ONl9nfzoGfeRFhvKTLX28MOD_nvT8cfI41-FylvNvvHm) where more than 20,000$ of liquidity is present.

Thank you and hope you verify the token as soon as you can.