### PR TITLE
Add YHUH Token and LAMB Token to verified (Jetton verification request)

### DIFF
--- a/jettons/LAMB.yaml
+++ b/jettons/LAMB.yaml
@@ -1,0 +1,9 @@
+name: Yahusha Token
+description: Finally, a token named after our messiah, the sacrificial lamb. Yahusha means \"Salvation of Yahuah\" His name is not Jesus
+image: "https://i.postimg.cc/rFmcXMyc/Yahusha-Token-LAMB.png"
+address: EQCjKpocnxHe-doD54HP2LVw6oYuLfD-CPihb7sUK9YrtnKz
+symbol: LAMB
+websites: 
+  - 
+social: 
+  - "https://t.me/YahushaLAMBtoken"

--- a/jettons/YHUH.yaml
+++ b/jettons/YHUH.yaml
@@ -1,0 +1,9 @@
+name: Yahuah Token
+description: Finally, a token named after our God, the creator, YHUH or Yahuah. The name given to Moses in Exodus 3:15. the hebrew name is the letters YHUH in english
+image: "https://i.postimg.cc/bJTMcrwH/Yahuah-Token-YHUH.png"
+address: EQBRr8kkZRYQr97C8vlQe-zrekBfOdXku_izyDUQLCPwb766
+symbol: YHUH
+websites: 
+  - 
+social: 
+  - "https://t.me/YahuahYHUH"


### PR DESCRIPTION
THIS IS NOT TO MEANT TO CONVINCE ANYONE TO USE THE NAMES though i believe you should BUT THIS IS TO GIVE PEOPLE THE OPPORTUNITY TO CHOOSE FOR THEMSELVES BECAUSE OUR CHOICE WAS TAKEN AWAY WHEN A GROUP OF PEOPLE REMOVED THE NAMES FROM SCRIPTURE OVER 6,800 TIMES. I RAISE AWARENESS TO GIVE A CHOICE AND TO INFORM PEOPLE BECASUE MANY DONT KNOW JUST LIKE I NEVER KNEW AND MANY JUST LIKE THE OLD ME HAVENT READ THE BIBLE, THEY TRUST MAN FOR ALL OF THEIR INFORMATION AND MAN IS IN ERROR, INCLUDING ME SOMETIMES SO CHECK FOR YOURSELVES WITH THE ORIGINAL SCRIPTURE DO HEBREW WORD STUDIES AND LOOK INTO THE TETRAGRAMMATON WHICH IS THE 4 LETTER NAME OF GOD GIVEN TO MOSES FOR ALL THE GENERATIONS TO COME. BEFORE I START EXPLAINING A LITTLE KNOW THAT THE TRUE NAME OF GOD IS יהוה WHICH ARE 4 HEBREW LETTERS TRANSLATED, ORIGINALLY, TO YHUH IN ENGLISH. WE ADD THE VOWELS (A's) FROM ADONAI (LORD) TO VOCAIZE THE NAME DUE TO PRONUNCIATION BEING LOST SO THE CLOSEST RENDERING WE HAVE TO THE HOLY NAME IS YAHUAH. MOST SAY JEHOVAH OR YAHWEH (AT LEAST THEY ARE TRYING) BUT THERE WAS NO J, V, OR W BACK THEN. WHAT IS NOW USED AS MOSTLY W AND V, WAS ORIGINALLY THE U, OR Uau TO BE EXACT. 
Over time with Satan's attacks against humankind and his attempt to separate us from our creator, he whispered into the Hebrew peoples ears that God's name was too holy and sacred to speak aloud. The Jews fell for this deception believing it to be a word from God but the verry thing he told them about the sacred name goes against scripture. In scripture, God tells us many times to call upon his name and to exalt his name. He and Jesus names are supposed to be the two most powerful names in existence. But the Jewish people stopped vocalizing the name and in they fought to have the name removed from the bible over 6,800 times. That's almost 7000 edits to the bible at one time to keep the names from reaching our eyes and ears.  So the names were mostly lost to history after they took "God" and "Jesus" names in vain (brought there names to naught or nothing). Calling "God" by titles that's attributed to most pagan gods such as Lord and God does not honor him and is not calling upon his name as we were instructed to do. And Jesus was just flat out created by man with a Pagan name "Iesous" pronounced 'yay-soose' and shortened to Jesus in 'is' so you have, pretty much, God is Zeus from my studies of Hebrew and and the translations/transliterations to other languages (Latin and Greek). So those in power corrupted both the names as to not call upon them hoping they would die out and people could worship the same gods as them under an alias. This is not an attempt to cause confusion or even try to convince you of these truths. you can believe man and google when it comes to the truth or you can seek and find yourself through your Father. There's many people, i was one of them, that was never even aware that God give us a name to call him for generations till the end of time until i was led to study the Hebrew language and a lot of what i was taught by Christians was false and in error. the meanings to a lot of things changed when you read in the original chosen language and you get the proper context and meanings. There's much that has been revealed to me but certain revelations are simply personal revelations meant to only reveal certain truths to the select few and those are not meant to be revealed to the world because they wouldn't believe in this time of great deception. thank you for at least giving me the opportunity to try to make these tokens verified on tonkeeper. it would mean a lot to my cause to have this as another way of reaching certain people who may not be in the crowd or area to learn of these things but is interested in cryptocurrency. sometimes just the power of suggestion can change your life.