### PR TITLE
Add SMG token (Squid Mini Game)

### DIFF
--- a/jettons/EQCkzTLN0UGAi3woWdtTHfXaJU29v5bppTKmx4MtdsL5bED1.yaml
+++ b/jettons/EQCkzTLN0UGAi3woWdtTHfXaJU29v5bppTKmx4MtdsL5bED1.yaml
@@ -1,0 +1,11 @@
+address: EQCkzTLN0UGAi3woWdtTHfXaJU29v5bppTKmx4MtdsL5bED1
+name: SMG
+symbol: SMG
+decimals: 6
+description: Squid Mini Game Token
+image: https://raw.githubusercontent.com/jeong24/smg/15427d462b8cefdacee911561e99f628d80a39af/Smg_token256.svg
+web: https://www.squidminigame.com
+social:
+  - telegram: https://t.me/SquidMiniGame_Community/3
+  - twitter: https://x.com/squid_minigame
+  - docs: https://squid-mini-game.gitbook.io/squid-mini-game-docs


### PR DESCRIPTION
Jetton metadata for SMG token.

- Jetton Master Address: EQCkzTLN0UGAi3woWdtTHfXaJU29v5bppTKmx4MtdsL5bED1
- Symbol: SMG
- Name: Squid Mini Game Token
- Decimals: 6
- Website: https://www.squidminigame.com
- Telegram: https://t.me/SquidMiniGame_Community/3
- Twitter: https://x.com/squid_minigame
- Docs: https://squid-mini-game.gitbook.io/squid-mini-game-docs
- Logo: https://raw.githubusercontent.com/jeong24/smg/15427d462b8cefdacee911561e99f628d80a39af/Smg_token256.svg

Please verify this token on Tonkeeper.

