### PR TITLE
Add verification for MonopolyCoin (MNPL)

### DIFF
--- a/jettons/MNPL.yaml
+++ b/jettons/MNPL.yaml
@@ -1,0 +1,10 @@
+name: Monopolyсoin
+description: MonopolyCoin (MNPL) is a universal in-game currency used for travel and purchases in the Telegram game @MNPLGAMEBOT. Play, explore, make deals, and build your empire with MNPL!
+address: EQDqStCkgMIaT0OCV5eGhiQS9JPd1TQiaMFTgnKABUwRsykw
+image: "https://i.imgur.com/XCxRUUc.png"
+symbol: MNPL
+websites:
+  - "https://mnpl.space"
+social:
+  - "https://x.com/mnplcoin"
+  - "https://t.me/mnplcoin"


### PR DESCRIPTION
name: MonopolyCoin
description: MonopolyCoin (MNPL) is a universal in-game currency used for travel and purchases in the Telegram game @MNPLGAMEBOT. Play, explore, make deals, and build your empire with MNPL!
address: EQDqStCkgMIaT0OCV5eGhiQS9JPd1TQiaMFTgnKABUwRsykw
symbol: MNPL
image: "https://mnpl.space/static/image/logo.jpg"
websites:
  - "https://mnpl.space"
social:
  - "https://x.com/mnplcoin"
  - "https://t.me/mnplcoin"
