### PR TITLE
Add metadata for Kasongo Coin ($KGO)

### DIFF
--- a/jettons/mainnet/EQDXLBzdtWb47zCy_-TnVASDa7kxAP7_A6G_UGt7lQEbGD_5.yaml
+++ b/jettons/mainnet/EQDXLBzdtWb47zCy_-TnVASDa7kxAP7_A6G_UGt7lQEbGD_5.yaml
@@ -1,0 +1,13 @@
+address: EQDXLBzdtWb47zCy_-TnVASDa7kxAP7_A6G_UGt7lQEbGD_5
+name: Kasongo Coin
+symbol: KGO
+description: Kasongo Coin is the ultimate underdog meme token, inspired by a fearless warthog who defies the odds and takes on the jungle. Kasongo is for the people.
+decimals: 9
+image: https://github.com/Kingsolomon1985/Kasongo-coin-assets/raw/main/Kasongo-coin-logo.png
+websites:
+  - https://x.com/KasongoCoin
+social:
+  - https://t.me/+I12WfCmXapBjNmE0
+  - https://www.tiktok.com/@kasongo.coin
+  - https://www.instagram.com/kasongo.coin
+


### PR DESCRIPTION
This pull request adds the required metadata for Kasongo Coin ($KGO) to the TON assets repository for verification.

- Contract address: EQDXLBzdtWb47zCy_-TnVASDa7kxAP7_A6G_UGt7lQEbGD_5
- Decimals: 9
- Image: https://github.com/Kingsolomon1985/Kasongo-coin-assets/blob/main/Kasongo-coin-logo.png?raw=true
- Description: Kasongo Coin is the ultimate underdog meme token, inspired by a fearless warthog who defies the odds and takes on the jungle. Kasongo is for the people.
- Socials:
  - Twitter: https://x.com/KasongoCoin
  - Telegram: https://t.me/+I12WfCmXapBjNmE0
  - TikTok: https://www.tiktok.com/@kasongo.coin
  - Instagram: https://www.instagram.com/kasongo.coin

Please review and consider verifying this token.
