### PR TITLE
Add GGWIN token metadata

### DIFF
--- a/jettons/ggwin.yaml
+++ b/jettons/ggwin.yaml
@@ -1,0 +1,12 @@
+name: GGWIN
+address: EQAp-NyM8PoERHSHDDCJahhxtkF3MUbmi_sC8iaLn-kjcrad
+symbol: GGWIN
+decimals: 9
+image: https://ggwin.life/meta/ggwin.png
+description: Web3-токен, который растёт от побед в Dota 2. Холди NFT + GGWIN и участвуй в роялти стримов.
+websites:
+  - https://ggwin.life
+social:
+  - https://t.me/ggwin_token
+  - https://twitch.tv/uzsoul
+  - https://x.com/ggwin_token


### PR DESCRIPTION
Добавлен GGWIN — Web3-геймифицированный токен, связанный с победами в Dota 2.
Контракт на Blum, Ston.Fi Dedust 126 NFT, стрим-роялти, сайт, активная комьюнити.
