### PR TITLE
Add KICH token metadata

### DIFF
--- a/jettons/jettons/EQC8eLIsQ4QLssWiJ_lqxShW1w7T1G11cfh-gFSRnMze64HI/meta.json
+++ b/jettons/jettons/EQC8eLIsQ4QLssWiJ_lqxShW1w7T1G11cfh-gFSRnMze64HI/meta.json
@@ -1,0 +1,7 @@
+{
+  "address": "EQC8eLIsQ4QLssWiJ_lqxShW1w7T1G11cfh-gFSRnMze64HI",
+  "symbol": "KICH",
+  "name": "KICH COIN",
+  "decimals": 9,
+  "logoURI": "https://i.ibb.co/YFXTRqKD/Picsart-24-09-02-16-47-01-542.png"
+}


### PR DESCRIPTION
Token metadata submission: KICH COIN

Jetton Master Address:  
https://tonviewer.com/EQC8eLIsQ4QLssWiJ_lqxShW1w7T1G11cfh-gFSRnMze64HI

Name: KICH COIN  
Symbol: KICH  
Decimals: 9  
Logo: https://i.ibb.co/YFXTRqK/Picsart-24-09-02-16-47-01-542.png

Notes:
- Проект находится на ранней стадии разработки
- Токен создан как основа для будущей внутренней экономики
- Публичный запуск будет позже, сайт и соцсети сейчас в разработке
- Jetton нужен для корректного отображения в TON Keeper и других кошельках
