### PR TITLE
Add CT token (CTSwap) metadata

### DIFF
--- a/jettons/ctswap.yaml
+++ b/jettons/ctswap.yaml
@@ -1,0 +1,6 @@
+address: EQDOWZFDyYQaDHEdB7SAdfrNwurfeMnS0T5jklhQDLjZG2h7
+name: CTSwap
+symbol: CT
+decimals: 9
+image: https://raw.githubusercontent.com/CTSwap/website/main/logo.png
+description: CTS powers the CrossTokenSwap DEX on TON, enabling fast swaps and rewards.


### PR DESCRIPTION
Please add CTS token (CrossTokenSwap) to the Tonkeeper verified token list.

- Token name: CTSwap
- Symbol: CT
- Decimals: 9
- Jetton Address: EQDOWZFDyYQaDHEdB7SAdfrNwurfeMnS0T5jklhQDLjZG2h7
- Logo: https://raw.githubusercontent.com/CTSwap/website/main/logo.png
- Description: CTS powers the CrossTokenSwap DEX on TON, enabling fast swaps and rewards.

Thank you for reviewing!