### PR TITLE
GEC token for Tonkeeper verification

### DIFF
--- a/jettons/GEC.yaml
+++ b/jettons/GEC.yaml
@@ -1,0 +1,9 @@
+name: GEC Coin
+description: Official Coin of GEC
+image: "https://tomato-occasional-tiglon-859.mypinata.cloud/ipfs/bafkreigqa6v7wi6je5dftkfp3xf6t4oxt5n6wzrtxrka7erv4wemid36je"
+address: EQAzqPY3J394aYI6YPTBQ2oMacrLnZzXNlP6ISZJtF6DJHhL
+symbol: GEC
+decimals: 9
+social:
+  - "https://x.com/GEC_Coin_"
+  - "https://t.me/GEC_Coin_community"


### PR DESCRIPTION
Added GEC Coin

This pull request adds the GEC token YAML file for verification on Tonkeeper.

name: GEC Coin
description: Official Coin of GEC
image: "https://tomato-occasional-tiglon-859.mypinata.cloud/ipfs/bafkreigqa6v7wi6je5dftkfp3xf6t4oxt5n6wzrtxrka7erv4wemid36je"
address: EQAzqPY3J394aYI6YPTBQ2oMacrLnZzXNlP6ISZJtF6DJHhL
symbol: GEC
decimals: 9
social:
  - "https://x.com/GEC_Coin_"
  - "https://t.me/GEC_Coin_community"
