### PR TITLE
Create VXN.yaml

### DIFF
--- a/jettons/VXN.yaml
+++ b/jettons/VXN.yaml
@@ -1,0 +1,16 @@
+name: VXN
+description: >
+  VXN is a custom utility token deployed on the TON blockchain. It was created as part of a broader vision to integrate digital scarcity, artistic identity, and decentralized value into a single symbol.
+
+  While functioning as a standalone digital asset, VXN is also conceptually linked to a 1-of-1 NFT artwork titled “VXN: ΩNE – The Pure Singularity of Digital Creation,” listed on the GetGems marketplace.
+
+  Learn more about the NFT at: https://vxnone.carrd.co
+
+  The token embodies originality, innovation, and future-facing digital ownership—positioning itself as a rare conceptual asset in the TON ecosystem.
+address: EQBbRAs71Nq-_Ni8LA5RTS-4yTYSu6F2APLxMkCkp-JSimXC
+symbol: VXN
+decimals: 9
+image: https://uploadkon.ir/uploads/6bc228_2509cc9e77-4f25-40a7-9036-3947843ae498.png
+social:
+  - type: website
+    url: https://vxnone.carrd.co


### PR DESCRIPTION
Add VXN Token to Tonkeeper jettons list

```yaml
address: EQBbRAs71Nq-_Ni8LA5RTS-4yTYSu6F2APLxMkCkp-JSimXC
symbol: VXN
websites:
  - "https://vxnone.carrd.co"  # This is the NFT website, not a dedicated token site
social: []

VXN is a custom utility token deployed on the TON blockchain. It was created as part of a broader vision to integrate digital scarcity, artistic identity, and decentralized value into a single symbol.

While functioning as a standalone digital asset, VXN is also conceptually linked to a unique 1-of-1 NFT artwork titled “VXN: ΩNE – The Pure Singularity of Digital Creation,” listed on the GetGems marketplace.

📝 Note: The linked website (https://vxnone.carrd.co) is the official page for the NFT artwork, which is closely associated with the VXN token. A dedicated token website will be added in the future.

Logo:https://uploadkon.ir/uploads/6bc228_2509cc9e77-4f25-40a7-9036-3947843ae498.png