### PR TITLE
Add GreenTree (GT) Jetton

### DIFF
--- a/jettons/EQBZm_Ieg9o9UMV57KTaIXICg7Zli15V4_2PCY2cmSSJWOkE.yaml
+++ b/jettons/EQBZm_Ieg9o9UMV57KTaIXICg7Zli15V4_2PCY2cmSSJWOkE.yaml
@@ -1,0 +1,12 @@
+name: GreenTree
+symbol: GT
+decimals: 9
+address: EQBZm_Ieg9o9UMV57KTaIXICg7Zli15V4_2PCY2cmSSJWOkE
+image: https://gateway.pinata.cloud/ipfs/bafkreid37tqxajcsxhjdogp6qv4kswaqipidw43dabkrn7kyg6zicvq6im
+description: GreenTree Jetton for the GreenTree airdrop on TON.
+websites:
+  - https://greentreebot.com
+social:
+  - https://t.me/Green_Treebot
+  - https://x.com/Green_Tree_coin
+  - https://www.youtube.com/@Green_Tree-o7f


### PR DESCRIPTION
This PR adds the GreenTree (GT) Jetton to the ton-assets list.

- Name: GreenTree
- Symbol: GT
- Decimals: 9
- Jetton master address: EQBZm_Ieg9o9UMV57KTaIXICg7Zli15V4_2PCY2cmSSJWOkE
- Image: https://gateway.pinata.cloud/ipfs/bafkreid37tqxajcsxhjdogp6qv4kswaqipidw43dabkrn7kyg6zicvq6im
- Description: GreenTree Jetton for the GreenTree airdrop on TON.
- Website: https://greentreebot.com
- Socials:
  - Telegram: https://t.me/Green_Treebot
  - X (Twitter): https://x.com/Green_Tree_coin
  - YouTube: https://www.youtube.com/@Green_Tree-o7f

The GreenTree project distributes GT through an airdrop campaign
and aims to support community growth with eco-friendly values.
