### PR TITLE
Add MOON token (request for SCAM label removal)

### DIFF
--- a/jettons/MOON.yaml
+++ b/jettons/MOON.yaml
@@ -1,0 +1,11 @@
+address: EQCUpGSwZtKNSYpt4YCD-Ge1RCAc3pmaFnI5NCyzjANtq9Ji
+name: MoonCoin
+symbol: MOON
+decimals: 9
+image: "https://mooncointon.com/images/Icon.PNG"
+description: "Community-driven token supporting Moon missions."
+social:
+  - "https://t.me/mooncryptoton"
+  - "https://x.com/mooncoin_ton"
+  - "https://www.instagram.com/mooncoin_ton"
+  - "https://mooncointon.com"


### PR DESCRIPTION
This PR adds the MOON token to ton-assets.

```yaml
address: EQCUpGSwZtKNSYpt4YCD-Ge1RCAc3pmaFnI5NCyzjANtq9Ji
name: MoonCoin
symbol: MOON
decimals: 9
image: "https://mooncointon.com/images/Icon.PNG"
description: "Community-driven token supporting Moon missions."
social:
  - "https://t.me/mooncryptoton"
  - "https://x.com/mooncoin_ton"
  - "https://www.instagram.com/mooncoin_ton"
  - "https://mooncointon.com"
   
We have revoked ownership, maintain transparency and provide a clear roadmap.  
This request is to remove the SCAM label and verify the token for proper display in Tonkeeper.