### PR TITLE
Add MOONX token (request for SCAM removal and verification)

### DIFF
--- a/jettons/MOON.yaml
+++ b/jettons/MOON.yaml
@@ -1,0 +1,11 @@
+address: EQCUpGSwZtKNSYpt4YCD-Ge1RCAc3pmaFnI5NCyzjANtq9Ji
+name: MoonCoin
+symbol: MOON
+decimals: 9
+image: "https://mooncointon.com/images/Icon.PNG"
+description: "Community-driven token supporting Moon missions."
+social:
+  - "https://t.me/mooncryptoton"
+  - "https://x.com/mooncoin_ton"
+  - "https://www.instagram.com/mooncoin_ton"
+  - "https://mooncointon.com"

--- a/jettons/moonx.yaml
+++ b/jettons/moonx.yaml
@@ -1,0 +1,15 @@
+name: "Moon"
+symbol: "MOONX"
+description: "Token built for the Moon, not just the charts. 50% of dev profit supports actual Moon missions."
+image: "https://mooncointon.com/images/Icon.PNG"
+address: "EQDO1reFVoStSzmNbpuISJI3qc8KnSR5LdtHyRcvfk0iQtlc"
+
+social:
+  - "https://mooncointon.com"
+  - "https://x.com/mooncoin_ton"
+  - "https://t.me/mooncryptoton"
+  - "https://www.instagram.com/mooncoin_ton"
+
+note: |
+  We have revoked ownership, maintain transparency and provide a clear roadmap.  
+  This request is to remove the SCAM label and verify the token for proper display in Tonkeeper.


### PR DESCRIPTION
We have revoked ownership, maintain transparency and provide a clear roadmap.  
This request is to remove the SCAM label and verify the token for proper display in Tonkeeper.