### PR TITLE
Add Materia jetton metadata

### DIFF
--- a/jettons/materia.yaml
+++ b/jettons/materia.yaml
@@ -1,0 +1,10 @@
+address: EQCBE5gGUQ_SzQnjYp8QHjH20ls4hT02_7g6u2D9Zs9enhlV
+name: "Materia"
+symbol: "MAT"
+decimals: 0
+description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
+image: "https://bafybeih2wdahfohmvgchcald22kslgfmb27vjp6k7tf4od76pto7egbnqi.ipfs.w3s.link/materia.svg"
+websites:
+  - "https://otherworlds.ru"
+social:
+  - "https://t.me/OtherWorldsTON"


### PR DESCRIPTION
Adding metadata for the "Materia" utility token of the 'Other Worlds' Metaverse.
Used for in-game purchases, upgrades and NFTs.


address: EQCBE5gGUQ_SzQnjYp8QHjH20ls4hT02_7g6u2D9Zs9enhlV
name: "Materia"
symbol: "MAT"
decimals: 0
description: "Utility token of the 'Other Worlds' Metaverse. Used for in-game purchases, upgrades and NFTs."
image: "https://bafybeih2wdahfohmvgchcald22kslgfmb27vjp6k7tf4od76pto7egbnqi.ipfs.w3s.link/materia.svg"
websites:
  - "https://otherworlds.ru"
social:
  - "https://t.me/OtherWorldsTON"