### PR TITLE
Add custodial wallet address

### DIFF
--- a/accounts/custodians.yaml
+++ b/accounts/custodians.yaml
@@ -405,3 +405,6 @@
   require_memo: true
 - address: "EQDQpuuVQI6Vzpewyll_xSP_SAlSNjXo9RngD9y99C8MVJri"
   name: "Flipster Withdrawal"
+- address: "EQCBdDjlsObrETq3TXP8lffsGSR9vm7iekLD0BZNYUw8oRAU"
+  name: "Ourbit"
+  require_memo: true


### PR DESCRIPTION
address: EQCBdDjlsObrETq3TXP8lffsGSR9vm7iekLD0BZNYUw8oRAU
name: Ourbit Exchange
description: "Official custodians wallet address of Ourbit Exchange"
websites:
  - "https://ourbit.com"
social:
  - "https://x.com/ourbit_official"
tags:
  - exchange
  - custodial