### PR TITLE
Add ELBA (ElbaCoin) jetton

### DIFF
--- a/jettons/ELBA.yaml
+++ b/jettons/ELBA.yaml
@@ -1,0 +1,8 @@
+name: ElbaCoin
+symbol: ELBA
+address: EQDr2wjYfTjF1b2n_LbMDX4rZFhnTpdSZUF3KhNySorxrVC5
+decimals: 9
+image: https://i.imgur.com/K4PvwYZ.png
+description: Utility token of Elba Adalid Media for community perks and access.
+social:
+  - https://www.elbaadalidmedia.com


### PR DESCRIPTION
Token: ElbaCoin (ELBA)
Jetton address (minter): EQDr2wjYfTjF1b2n_LbMDX4rZFhnTpdSZUF3KhNySorxrVC5
Decimals: 9
Image: https://i.imgur.com/sgWEC66.png
Website: https://www.elbaadalidmedia.com
Description: Official token of Elba Adalid Media on TON.