### PR TITLE
Add MOONX token (request for SCAM removal and verification)

### DIFF
--- a/jettons/moonx.yaml
+++ b/jettons/moonx.yaml
@@ -1,0 +1,15 @@
+name: "Moon"
+symbol: "MOONX"
+description: "Token built for the Moon, not just the charts. 50% of dev profit supports actual Moon missions."
+image: "https://mooncointon.com/images/Icon.PNG"
+address: "EQDO1reFVoStSzmNbpuISJI3qc8KnSR5LdtHyRcvfk0iQtlc"
+
+social:
+  - "https://mooncointon.com"
+  - "https://x.com/mooncoin_ton"
+  - "https://t.me/mooncryptoton"
+  - "https://www.instagram.com/mooncoin_ton"
+
+note: |
+  We have revoked ownership, maintain transparency and provide a clear roadmap.  
+  This request is to remove the SCAM label and verify the token for proper display in Tonkeeper.


### PR DESCRIPTION
We have revoked ownership, maintain transparency and provide a clear roadmap.  
This request is to remove the SCAM label and verify the token for proper display in Tonkeeper.

Unlike the previous submission, the token already has 17+ holders and an active liquidity pool on STON.fi:  
https://app.ston.fi/pools/EQDO1reFVoStSzmNbpuISJI3qc8KnSR5LdtHyRcvfk0iQtlc