### PR TITLE
Add AURD token metadata

### DIFF
--- a/jettons/AURD.yaml
+++ b/jettons/AURD.yaml
@@ -1,0 +1,10 @@
+address: EQCUgOlOU0tCtU48cbVKPOYcJreg8rHEmOUMfhH5zgBu0dV0
+name: Dataurum
+symbol: AURD
+decimals: 9
+image: https://dataurum.io/metadata/token.jpg
+description: The utility token of Dataurum — the fair data economy on TON.
+websites:
+  - https://dataurum.io
+social:
+  - https://t.me/dataurum


### PR DESCRIPTION
address: EQCUgOlOU0tCtU48cbVKPOYcJreg8rHEmOUMfhH5zgBu0dV0
name: Dataurum
symbol: AURD
decimals: 9
image: https://dataurum.io/metadata/token.jpg
description: The utility token of Dataurum — the fair data economy on TON.
websites:
  - https://dataurum.io
social:
  - https://t.me/dataurum