### PR TITLE
Add EcoRise Coin (ERC)

### DIFF
--- a/jettons/EQCTKmnRfXDEEtTcrsQUPvUJNHqRX9b9MpBP9vvnQPpj5MMQ.json
+++ b/jettons/EQCTKmnRfXDEEtTcrsQUPvUJNHqRX9b9MpBP9vvnQPpj5MMQ.json
@@ -1,0 +1,9 @@
+{
+  "name": "EcoRise Coin",
+  "symbol": "ERC",
+  "decimals": 9,
+  "address": "EQCTKmnRfXDEEtTcrsQUPvUJNHqRX9b9MpBP9vvnQPpj5MMQ",
+  "website": "https://ecorisecoin.tilda.ws/eng",
+  "description": "Экологический и социальный токен EcoRise — 1% на благотворительность, 0.5% на развитие проекта.",
+  "logo": "https://i.ibb.co/ZpsQYrfk/erc-logo.png"
+}


### PR DESCRIPTION
address: 0:932a69d17d70c412d4dcaec4143ef509347a915fd6fd32904ff70be740fa63e4
symbol: ERC
name: EcoRise Coin
decimals: 9
websites:
  - "https://ecorisecoin.tilda.ws/eng"
social:
  - "https://t.me/ecorisecoin"
description: "Экологический и социальный токен EcoRise — 1% на благотворительность, 0.5% на развитие проекта."
logo: "https://i.ibb.co/ZpsQYrfk/erc-logo.png"

