### PR TITLE
feat(jettons): add H2C

### DIFF
--- a/jettons/H2C.yaml
+++ b/jettons/H2C.yaml
@@ -1,0 +1,12 @@
+name: Hash2Cash
+address: EQCxB3H7o_E3oA5ijBM655mz4j5wcNtO0Wwh_WsjtWoRkPfa
+description: "Hash2Cash is a cloud mining service using real ASICs with daily payments in BTC. 1 H2C = 1 TH/s. Details and a profitability calculator are available on the website and in the documentation."
+image: "https://hash2cash.io/assets/img/h2c-coin.png"
+symbol: H2C
+websites:
+  - "https://hash2cash.io/"
+  - "https://docs.hash2cash.io/"
+social:
+  - "https://t.me/hash2cashio"
+  - "https://x.com/hash2cashio"
+  - "https://www.tiktok.com/@hash2cash"


### PR DESCRIPTION
name: Hash2Cash
address: EQCxB3H7o_E3oA5ijBM655mz4j5wcNtO0Wwh_WsjtWoRkPfa
description: "Hash2Cash is a cloud mining service using real ASICs with daily payments in BTC. 1 H2C = 1 TH/s. Details and a profitability calculator are available on the website and in the documentation."
image: "https://hash2cash.io/assets/img/h2c-coin.png"
symbol: H2C
websites:
  - "https://hash2cash.io/"
  - "https://docs.hash2cash.io/"
social:
  - "https://t.me/hash2cashio"
  - "https://x.com/hash2cashio"
  - "https://www.tiktok.com/@hash2cash"