### PR TITLE
Create CHESS.yaml

### DIFF
--- a/jettons/CHESS.yaml
+++ b/jettons/CHESS.yaml
@@ -1,0 +1,8 @@
+name: Chess coin
+description: Utility token for mini-apps ecosystem. Used for in-app rewards and payments.
+image: "https://kovxo3hnk.github.io/CryptoFarm.github.io/assets/token_logo.png"
+address: EQBu2ATweuwQEt6CdI9mAnaayhS2gujsi1WLUu7O9APeXpQQ
+symbol: CHESS
+decimals: 9
+websites:
+  - "https://github.com/KOVXO3HNK/Chess2"


### PR DESCRIPTION
This PR adds the CHESS jetton to ton-assets.

• Name: Chess coin
• Symbol: CHESS
• Decimals: 9
• Jetton minter address: EQBu2ATweuwQEt6CdI9mAnaayhS2gujsi1WLUu7O9APeXpQQ
• Image: https://kovxo3hnk.github.io/CryptoFarm.github.io/assets/token_logo.png
• Project page: https://github.com/KOVXO3HNK/Chess2

Description:
CHESS is a utility token for the WorldwideChess / Cryptofarm / etc mini-apps (rewards, in-app purchases, community incentives). 

If anything is missing or needs adjustment, please let me know — happy to update.