### PR TITLE
Add new token "1coin" (ONE) to TON Assets

### DIFF
--- a/jettons/MyToken.yaml
+++ b/jettons/MyToken.yaml
@@ -1,5 +1,5 @@
 name: "TalantaCoin"
-symbol: "TALC"
+symbol: "TALA"
 decimals: 9
 total_supply: 566000000
 address: "EQApMLWrrWyZD10mP6LEcV4uprfXa7ka8np8CK6s4ESMKsI7"

--- a/jettons/MyToken.yaml
+++ b/jettons/MyToken.yaml
@@ -1,0 +1,5 @@
+name: "TalantaCoin"
+symbol: "TALC"
+decimals: 9
+total_supply: 566000000
+address: "EQApMLWrrWyZD10mP6LEcV4uprfXa7ka8np8CK6s4ESMKsI7"


### PR DESCRIPTION
Add new token "1coin" (ONE) to TON Assets.

- Token address: EQBu0-tgM-W1UxE6MTLlNTk01p0fLIMjCA9GeLThFrd-Bkxp
- Total supply: 3,800,000,000
- Decimals: 9
- Symbol: ONE

This token is created on the TON blockchain and ready to be verified and added to TON Wallets.