### PR TITLE
Add TONE (The Open Network Energy) — EQA40ubhnA5-lpS27VJvBJAReHKrC3fW4Owlyb4TVYd2CAZW

### DIFF
--- a/jettons/jettons/EQA40ubhnA5-lpS27VJvBJAReHKrC3fW4Owlyb4TVYd2CAZW.yaml
+++ b/jettons/jettons/EQA40ubhnA5-lpS27VJvBJAReHKrC3fW4Owlyb4TVYd2CAZW.yaml
@@ -1,0 +1,12 @@
+address: EQA40ubhnA5-lpS27VJvBJAReHKrC3fW4Owlyb4TVYd2CAZW
+name: The Open Network Energy
+symbol: TONE
+decimals: 9
+image: https://tonece.com/tone-256.png
+description: >
+  TONE (The Open Network Energy) — a community-driven utility jetton on TON,
+  powering participation, payments, and perks across apps and games.
+  TONE is an independent community token and is not affiliated with or endorsed by The Open Network.
+websites:
+  - https://tonece.com
+social: []


### PR DESCRIPTION
- Jetton name: The Open Network Energy
- Symbol: TONE
- Decimals: 9
- Master address: EQA40ubhnA5-lpS27VJvBJAReHKrC3fW4Owlyb4TVYd2CAZW
- Image (direct link): https://tonece.com/tone-256.png
- Website: https://tonece.com
- Off-chain metadata (TEP-64): https://tonece.com/tone.json

Notes:
- Independent community token; not affiliated with or endorsed by The Open Network.
