### PR TITLE
Add Bitza (BITZA) Jetton verification request

### DIFF
--- a/jettons/BITZA.yaml
+++ b/jettons/BITZA.yaml
@@ -1,0 +1,10 @@
+name: Bitza
+symbol: BITZA
+address: EQBJgrV3v34ATmXrexFmvZuux277BRoC1yX8PKbQtGLx-BFJ
+decimals: 9
+description: >
+  The Bitza meme token was created in honor of the renowned programmer Laszlo Hanyecz, who made history by purchasing two pizzas for 10,000 BTC — the first real-world transaction ever conducted with Bitcoin. This iconic event marked the beginning of cryptocurrency’s use as a medium of exchange and is now celebrated every year on May 22nd as Bitcoin Pizza Day.
+image: https://github.com/ManifestorX/images/blob/main/Bitza.png?raw=true
+social:
+  telegram: https://t.me/bitzatoken
+  twitter: https://t.me/bitzatoken


### PR DESCRIPTION
name: Bitza
symbol: BITZA
address: EQBJgrV3v34ATmXrexFmvZuux277BRoC1yX8PKbQtGLx-BFJ
decimals: 9
description: The Bitza meme token was created in honor of the renowned programmer Laszlo Hanyecz, who made history by purchasing two pizzas for 10,000 BTC — the first real-world transaction ever conducted with Bitcoin. This iconic event marked the beginning of cryptocurrency’s use as a medium of exchange and is now celebrated every year on May 22nd as Bitcoin Pizza Day.
image: https://github.com/ManifestorX/images/blob/main/Bitza.png?raw=true
social:
  telegram: https://t.me/bitzatoken

Created via TON Minter.

Please verify this jetton.
