### PR TITLE
Add RAdd RANNTA COIN metadata (TON)

### DIFF
--- a/jettons/jettons/RANNTA.yaml
+++ b/jettons/jettons/RANNTA.yaml
@@ -1,0 +1,12 @@
+address: EQBCY5Yj9G6VAQibTe6hz53j8vBNO234n0fzHUP3IUBBYbeR
+name: RANNTA COIN
+symbol: RANNTA
+decimals: 9
+image: https://raw.githubusercontent.com/ilia144000/rannta-token/main/image.png
+description: A memorial for the tragic Los Angeles fire. A symbol for rebuilding and returning to the glory of the United States.
+websites:
+  - https://rannta.com
+social:
+  twitter: https://x.com/ranntacoin
+  telegram: https://t.me/rannta_coin
+  github: https://github.com/ilia144000/rannta-token


### PR DESCRIPTION
### Add metadata for RANNTA COIN (TON Jetton)

This PR adds verified metadata for the TON Jetton **RANNTA COIN**.

- **Jetton master address:** EQBCY5Yj9G6VAQibTe6hz53j8vBNO234n0fzHUP3IUBBYbeR  
- **Decimals:** 9  
- **Symbol:** RANNTA  
- **Image:** https://raw.githubusercontent.com/ilia144000/rannta-token/main/image.png  
- **Website:** https://rannta.com  

**Transparency note:**  
The Jetton master ownership has been permanently transferred to a **neutral (burned) address**  
`UQAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAJKZ`  
to ensure complete decentralization, immutability of metadata, and public trust.  
This means no further minting or admin changes are possible.

**Purpose:**  
Originally created as a symbolic memorial for the tragic Los Angeles fire —  
RANNTA COIN now stands as the utility token of the **RANNTAverse** ecosystem and NFT marketplace.

All metadata fields follow the official Tonkeeper YAML structure and validation requirements.
