### PR TITLE
Add ELZR (Eliezer Token) – Verified Jetton with LIVE Mini-App

### DIFF
--- a/jettons/ELZR.yaml
+++ b/jettons/ELZR.yaml
@@ -1,0 +1,9 @@
+name: Eliezer Token
+description: Eliezer (ELZR) is a TON-based utility token powering mini-apps, payments, and rewards on Telegram. Users earn ELZR through tap-to-earn games, staking, and community tasks. Built for speed, low fees, and seamless integration with Telegram wallets.
+image: "https://raw.githubusercontent.com/Iulian85/eliezer-token/main/ELZR.png"
+address: EQDnqX9FX7UTUC7Kmjzr-MseRjx1eI2aJxLdnGQ3NSuKJb-X
+symbol: ELZR
+decimals: 9
+social:
+  - telegram: https://t.me/EliezerTokenOfficial
+  - telegram_bot: https://t.me/Obadiah_Bot

--- a/jettons/ELZR.yaml
+++ b/jettons/ELZR.yaml
@@ -4,6 +4,8 @@ image: "https://raw.githubusercontent.com/Iulian85/eliezer-token/main/ELZR.png"
 address: EQDnqX9FX7UTUC7Kmjzr-MseRjx1eI2aJxLdnGQ3NSuKJb-X
 symbol: ELZR
 decimals: 9
+websites:
+  - "https://github.com/Iulian85/eliezer-tapswap"
 social:
-  - telegram: https://t.me/EliezerTokenOfficial
-  - telegram_bot: https://t.me/Obadiah_Bot
+  - telegram: "https://t.me/EliezerTokenOfficial"
+  - telegram_bot: "https://t.me/Obadiah_Bot"


### PR DESCRIPTION
# Add ELZR (Eliezer Token) – Verified Jetton

**ELZR has real utility on TON – mini-app LIVE.**

- **Address:** `EQDnqX9FX7UTUC7Kmjzr-MseRjx1eI2aJxLdnGQ3NSuKJb-X` (Tonviewer verified)  
- **Symbol:** `ELZR`  
- **File:** `jettons/ELZR.yaml` (**uppercase – matches HMSTR, NOT, CATGOLD**)  
- **Logo:** 256x256 PNG – https://raw.githubusercontent.com/Iulian85/eliezer-token/main/ELZR.png  
- **Tap-to-Earn Mini-App (LIVE):** https://github.com/Iulian85/eliezer-tapswap  
- **Social:**  
  - Group: https://t.me/EliezerTokenOfficial  
  - Bot: https://t.me/Obadiah_Bot  

**DEX pool (STON.fi USDT) coming soon – not required for verification.**  
**Follows official TON Assets standards.**

**Ready for verification.**
