### PR TITLE
Add Socool Domains collection

### DIFF
--- a/collections/socool-domains.yaml
+++ b/collections/socool-domains.yaml
@@ -1,0 +1,6 @@
+name: Socool Domains
+description: Subdomain NFTs for .socool.ton - Register your unique subdomain on TON blockchain with full DNS resolution support (wallet, ADNL, TON Storage).
+image: "https://socool.ton.resistance.dog/api/collection.png"
+address: "0:e40f2ae3c38db416a1bf6f1c1b2cf95547356f830119219e4f6aee661db7bfc1"
+websites:
+  - "https://socool.ton.resistance.dog"


### PR DESCRIPTION
## Summary
Adding **Socool Domains** NFT collection for `.socool.ton` subdomains.

## Collection Details
- **Name**: Socool Domains
- **Address**: `0:e40f2ae3c38db416a1bf6f1c1b2cf95547356f830119219e4f6aee661db7bfc1`
- **Website**: https://socool.ton.resistance.dog
- **Domain**: socool.ton

## Features
- Subdomain NFTs with full DNS resolution
- Support for wallet, ADNL, and TON Storage records
- TEP-62 and TEP-64 compliant