### PR TITLE
Add KUBA Jetton

### DIFF
--- a/jettons/KUBA.yaml
+++ b/jettons/KUBA.yaml
@@ -1,0 +1,7 @@
+address: EQDCCMpdq2lab20fVNcXTx44TrGfAnNDvWiFWt9wDfDUY5YT
+name: KUBA
+symbol: KUBA
+decimals: 9
+image: ipfs://bafkreidethyrgyqny6goboujdkfsyomfek3l6psq4gahpkkewfxbflfuuy
+description: |
+  KUBA is a playful community-driven token built around the fun and mischievous spirit of Kuba AI — a Telegram mini-app bot designed to entertain, troll lightly, and brighten conversations. It serves as the native reward token within the Kuba ecosystem, used for missions, interactions, and community activities. In the future, KUBA will expand into more utilities including a swap platform similar to ston.fi, a token-creation toolkit, and potentially its own blockchain network. KUBA isn’t just a token — it’s the beginning of a growing, humorous, and experimental Web3 world.


### PR DESCRIPTION
address: EQDCCMpdq2lab20fVNcXTx44TrGfAnNDvWiFWt9wDfDUY5YT
symbol: KUBA
decimals: 9
name: Kuba Token
description: >
  A fun, community-driven token powering the playful AI ecosystem inside the Kuba Telegram Mini App.
  Designed for entertainment, stress relief, and interaction with the mischievous Kuba AI bot,
  the token serves as rewards for users and will later expand into a full platform that includes
  token creation tools, swapping features similar to ston.fi, and future plans toward developing
  its own chain.
image: "ipfs://bafkreidethyrgyqny6goboujdkfsyomfek3l6psq4gahpkkewfxbflfuuy"
websites:
  - "https://github.com/sunantongsan/kuba-token-metadata"
social:
  - "https://t.me/kubaminer_bot"
  - "https://x.com/KubacoinAirdrop"
