### PR TITLE
Add SEAMLESS token metadata

### DIFF
--- a/jettons/$SEAMLESS.yaml
+++ b/jettons/$SEAMLESS.yaml
@@ -1,0 +1,10 @@
+ "address": "0:8398665196574b5ba3ef1cb358f308c30626eb1fa7c1d94f3ffee3d96b0d54ee",
+  "name": "seamless",
+  "symbol": "SEAMLESS",
+  "decimals": "9",
+  "image": "https://harlequin-rear-marsupial-587.mypinata.cloud/ipfs/bafybeigoinzrcd5vabmvw7qa6sisqzuotwhfshuilag6q6py7ghmkza3oe",
+  "description": "Seamless token is designed for fast and low-cost transactions on the TON network."
+"websites":
+  "https://builder.hostinger.com/3PYfUl6aa1mAVp59/preview"
+"social":
+  "telegram": "https://t.me/+2KVH8GPlooNjODc1"


### PR DESCRIPTION
jettons/$SEAMLESS.yaml
 "address": "0:8398665196574b5ba3ef1cb358f308c30626eb1fa7c1d94f3ffee3d96b0d54ee",
  "name": "seamless",
  "symbol": "SEAMLESS",
  "decimals": "9",
  "image": "https://harlequin-rear-marsupial-587.mypinata.cloud/ipfs/bafybeigoinzrcd5vabmvw7qa6sisqzuotwhfshuilag6q6py7ghmkza3oe",
  "description": "Seamless token is designed for fast and low-cost transactions on the TON network."
"websites":
  "https://builder.hostinger.com/3PYfUl6aa1mAVp59/preview"
"social":
  "telegram": "https://t.me/+2KVH8GPlooNjODc1"