### PR TITLE
Add VIC, TVIC, and WIR tokens from TON.FUN platform

### DIFF
--- a/jettons/TVIC.yaml
+++ b/jettons/TVIC.yaml
@@ -1,0 +1,12 @@
+name: TestVic
+symbol: TVIC
+address: EQCxD4q_M7rvyC58r8RwUjev4ODGgdcohOMQfxzGYGvpJCIe
+image: "https://ton.fun/jettons/TVIC.png"
+description: |
+  TestVic token - Testing token for TON.FUN platform development and testing.
+  Used for platform testing and verification purposes.
+websites:
+  - "https://ton.fun"
+social:
+  - "https://t.me/TonFunX"
+  - "https://x.com/TonFunX"

--- a/jettons/VIC.yaml
+++ b/jettons/VIC.yaml
@@ -1,0 +1,12 @@
+name: VicJet
+symbol: VIC
+address: EQBcYtlc9Wn_y8WKuxm04jxMbC8728dOVQWIhdoI_UgC_iq7
+image: "https://ton.fun/jettons/VIC.png"
+description: |
+  VicJet token - Trading and gaming token on TON.FUN launchpad platform.
+  Deployed via bonding curve mechanism with 1% trading fees.
+websites:
+  - "https://ton.fun"
+social:
+  - "https://t.me/TonFunX"
+  - "https://x.com/TonFunX"

--- a/jettons/WIR.yaml
+++ b/jettons/WIR.yaml
@@ -1,0 +1,13 @@
+name: WIR Fund
+symbol: WIR
+address: EQAw-RI_4boPd6HwcKTY4nYJ1zj_b__hS0t56eM2HPIlyHid
+image: "https://ton.fun/jettons/WIR.png"
+description: |
+  WIR Fund token - Powers WIR.FUND poker platform with real token gameplay.
+  Texas Hold'em poker using actual WIR tokens as chips. Grade A- audit with 90% score.
+websites:
+  - "https://wir.fund"
+  - "https://ton.fun"
+social:
+  - "https://t.me/TonFunX"
+  - "https://x.com/TonFunX"


### PR DESCRIPTION
Adding three tokens from TON.FUN launchpad platform:

**VIC (VicJet)**
- Symbol: VIC
- Address: EQBcYtlc9Wn_y8WKuxm04jxMbC8728dOVQWIhdoI_UgC_iq7
- Decimals: 9
- Supply: 31.58M
- Description: Trading and gaming token
- Logo: https://ton.fun/jettons/VIC.png

**TVIC (TestVic)**
- Symbol: TVIC
- Address: EQCxD4q_M7rvyC58r8RwUjev4ODGgdcohOMQfxzGYGvpJCIe
- Decimals: 9
- Supply: 3.27M
- Description: Testing token
- Logo: https://ton.fun/jettons/TVIC.png

**WIR (WIR Fund)**
- Symbol: WIR
- Address: EQAw-RI_4boPd6HwcKTY4nYJ1zj_b__hS0t56eM2HPIlyHid
- Decimals: 9
- Supply: 210M
- Description: Powers WIR.FUND poker platform with real token gameplay
- Logo: https://ton.fun/jettons/WIR.png

All tokens are deployed on TON mainnet with proper metadata and logos.

**Platforms:**
- TON.FUN: https://ton.fun
- WIR.FUND Poker: https://wir.fund
- Twitter: https://x.com/TonFunX
- Telegram: https://t.me/TonFunX