### PR TITLE
Add DeDust LP metadata for CODEX/TON

### DIFF
--- a/jettons/DEDUST-CODEX-TON-LP.yaml
+++ b/jettons/DEDUST-CODEX-TON-LP.yaml
@@ -1,0 +1,17 @@
+address: "0:ff67ee2a9b982222070213309f8a8d6aeac8f3cf088cb265087e31a5bb919676"
+name: "DeDust Pool: CODEX/TON LP"
+symbol: "CODEX/TON LP"
+decimals: 9
+image: "https://cdn.codex.pm/images/wallets/dedust-lp-codex-ton.png"
+description: "Liquidity pool token for TON and CODEX ARCANUM on DeDust DEX"
+
+websites:
+  - "https://dedust.io/pools/EQD_Z-4qm5giIgcCEzCfio1q6sjzzwiMsmUIfjGlu5GWdpg7"
+  - "https://codex.pm"
+
+social:
+  - "https://twitter.com/codexarcanum"
+  - "https://t.me/CodexSouL"
+  - "https://t.me/CodexPulse"
+  - "https://t.me/CodexGateBot"
+  - "https://t.me/CodexGateBot/codexArcanum"


### PR DESCRIPTION
This PR adds official metadata for the DeDust Classic LP token (CODEX/TON).

- Main Token: CODEX ARCANUM (officially verified on TON blockchain)
- Existing Verified LP: pTON / CODEX LP on STON.fi
- New LP: Classic TON / CODEX liquidity pool on DeDust DEX

This LP is an additional liquidity venue and does not replace the STON.fi pTON LP.
Both pools are intended to coexist, serving different liquidity models.