### PR TITLE
Add Mini KRIPT (MKRIPT) jetton to assets

### DIFF
--- a/jettons/MKRIPT.yaml
+++ b/jettons/MKRIPT.yaml
@@ -1,0 +1,13 @@
+name: Mini KRIPT
+description: This is a token of a gaming project that we mine in our CryptoWorld. It is an essential tool in our ecosystem that enables progress within the game and the project. Our goal is to learn together how to mine the asset and manage it wisely.
+image: "https://kriptomir.io/logo.png"
+address: 0:db7e4a840e5b46eeebcde1775313554037feade1f60fd57ad9532850c25f0a49
+symbol: MKRIPT
+websites:
+  - "https://kriptomir.io/"
+social:
+  - "https://t.me/kriptofarmers"
+  - "https://t.me/kripto_farmeri"
+  - "https://x.com/kriptomir2024"
+bot:
+  - "https://t.me/kriptofarmbot"

--- a/jettons/MKRIPT.yaml
+++ b/jettons/MKRIPT.yaml
@@ -9,5 +9,4 @@ social:
   - "https://t.me/kriptofarmers"
   - "https://t.me/kripto_farmeri"
   - "https://x.com/kriptomir2024"
-bot:
   - "https://t.me/kriptofarmbot"


### PR DESCRIPTION
I would like to add the Mini KRIPT (MKRIPT) jetton to the Tonkeeper assets list. 

Mini KRIPT is a utility token for the "CryptoWorld" gaming ecosystem. It is used as a core asset for in-game progression and mining mechanics. Our project focuses on educating users about asset mining and strategic management within a gamified environment.

Token Details
- Name: Mini KRIPT
- Symbol: MKRIPT
- Contract Address: 0:db7e4a840e5b46eeebcde1775313554037feade1f60fd57ad9532850c25f0a49
- Website: https://kriptomir.io/
- Telegram Bot: https://t.me/kriptofarmbot

Verification
All social links, website, and the official logo are included in the JSON file. The token metadata is fully compliant with TEP-64.