### PR TITLE
Add LFG AI Market details to lfgsyndicate.yaml

### DIFF
--- a/accounts/lfgsyndicate.yaml
+++ b/accounts/lfgsyndicate.yaml
@@ -1,0 +1,3 @@
+name: LFG AI Market
+address: "0:c1655b8923ffbb1412e13204e35d9bf7a20681a9c37a89a0b947b72b38e437c3"
+icon: "https://raw.githubusercontent.com/LFGsyndicate/LFG-marketplace/main/public/icon-512.png"


### PR DESCRIPTION
## LFG AI Market Merchant Wallet

Adding merchant wallet for LFG AI Market - AI services marketplace on Telegram.

**Details:**
- Name: LFG AI Market
- TON DNS: lfgsyndicate.ton
- Telegram Bot: @lfg_ai_bot
- Website: Telegram Mini App
- Purpose: Receiving TON payments for AI services

The wallet address is correctly linked to our TON DNS domain.