### PR TITLE
Add EMRD jetton

### DIFF
--- a/jettons/EMRD.yaml
+++ b/jettons/EMRD.yaml
@@ -1,0 +1,10 @@
+name: Emerald Token
+symbol: EMRD
+address: EQDixzzOGdzTsmaVpqlOG9pBUv95hTIqhJMXaHYFRnfQgoXD
+decimals: 9
+image: https://greeny187.github.io/EmeraldContentBots/assets/emrd.png
+description: Emerald (EMRD) – Token aus dem Emerald Ökosystem.
+websites:
+  - https://greeny187.github.io/EmeraldContentBots/
+social:
+  - https://t.me/emeraldecosystem


### PR DESCRIPTION
Hi Tonkeeper team,
I’m submitting EMRD (Emerald Token) to the jetton registry so it can appear as verified in wallets.
Token details
Symbol: EMRD
Jetton master: (copy from jettons/EMRD.yaml to avoid typos)
Decimals: 9
Image: direct PNG hosted on GitHub Pages
Links: website + Telegram included in YAML
If you need any additional metadata (description/socials formatting/etc.), tell me and I’ll update the PR.
Thank you!