### PR TITLE
Create Gruwis.yaml

### DIFF
--- a/jettons/Gruwis.yaml
+++ b/jettons/Gruwis.yaml
@@ -1,0 +1,11 @@
+name: Gruwis
+address: "0:c7f83eaac160143f7c69ab0541194b3cd2a680b6ffb0f6745484fc8a92da13ef"
+symbol: GS
+decimals: 9
+websites:
+  - "https://man159.ru/"
+social:
+  - "https://t.me/gruwiscrypto"
+licence:
+  - "https://www1.fips.ru/fips_servl/fips_servlet?DB=RUTM&DocNumber=1148549"
+description: "Gruwis® - all time best fit. Грувис® - всегда оптимальный выбор."


### PR DESCRIPTION
Gruwis.yaml
name: Gruwis
address: "0:c7f83eaac160143f7c69ab0541194b3cd2a680b6ffb0f6745484fc8a92da13ef"
symbol: GS
decimals: 9
websites: 
- "https://man159.ru/"
social:
  - "https://t.me/gruwiscrypto"
licence:
  - "https://www1.fips.ru/fips_servl/fips_servlet?DB=RUTM&DocNumber=1148549"
description: "Gruwis® - all time best fit. Грувис® - всегда оптимальный выбор."
