### PR TITLE
Add BGMN jetton

### DIFF
--- a/jettons/BGMN.yaml
+++ b/jettons/BGMN.yaml
@@ -1,0 +1,4 @@
+name: BogemaNail
+description: BogemaNail jetton token
+address: "0:e3cb5e152b9a8b8b9ffb215c748813a0030a429c1cef52c12546d6c7b24f21a3"
+symbol: BGMN


### PR DESCRIPTION
This pull request adds a new jetton to the registry.

Name: BogemaNail  
Symbol: BGMN  
Jetton master address: 0:e3cb5e152b9a8b8b9ffb215c748813a0030a429c1cef52c12546d6c7b24f21a3  

The token is actively developed and intended to be used within a Telegram-based project.
