### PR TITLE
add h0nLands

### DIFF
--- a/collections/h0nLands.yaml
+++ b/collections/h0nLands.yaml
@@ -6,4 +6,4 @@ websites:
 social:
   - "https://t.me/theh0n"
   - "https://t.me/h0n_lands_bot"
-  - "https://x.com/h0ncommunity"
+  - "https://x.com/h0n_io"

--- a/collections/h0nLands.yaml
+++ b/collections/h0nLands.yaml
@@ -1,0 +1,9 @@
+name: H0N Lands
+description: H0N Lands is a limited NFT collection of digital plots that form a single world map. Each Land has a unique location and size and is permanently assigned to its owner on the blockchain.
+address: EQDNvr9qUjUZOvRytHJMchq8QZqTWnwwjlWfHJe5FMjZK_WO
+websites:
+  - "https://h0n.io/"
+social:
+  - "https://t.me/theh0n"
+  - "https://t.me/h0n_lands_bot"
+  - "https://x.com/h0ncommunity"


### PR DESCRIPTION
### Add H0N Lands NFT Collection

This PR adds the official metadata for the H0N Lands NFT collection.

H0N Lands is a limited NFT collection of digital plots that form a unified on-chain world map.  
Each Land has a fixed location and size and is permanently assigned to its owner on the blockchain.

---

Collection address:
EQDNvr9qUjUZOvRytHJMchq8QZqTWnwwjlWfHJe5FMjZK_WO

Official website:
https://h0n.io/

Social links:
https://t.me/theh0n
https://t.me/h0n_lands_bot
https://x.com/h0n_io