### PR TITLE
Add BjG Tapper Collectibles NFT metadata

### DIFF
--- a/collections/BjGTapperCollectibles.yaml
+++ b/collections/BjGTapperCollectibles.yaml
@@ -1,0 +1,3 @@
+name: "BjG Tapper Collectibles"
+description: "These NFTs are created by users in the Telegram Game BjG Tapper. User unveil a new NFT for each unique level and can download those to their wallet if they are a VIP member at which point they can be bought or sold."
+address: "EQDZdhm1yVVKmhGeLxZSkPi3HTvZqjGNnImsNXdwcRiaqkwi"

--- a/jettons/BjGTapperCollectibles.yaml
+++ b/jettons/BjGTapperCollectibles.yaml
@@ -1,6 +1,3 @@
 name: "BjG Tapper Collectibles"
 description: "These NFTs are created by users in the Telegram Game BjG Tapper. User unveil a new NFT for each unique level and can download those to their wallet if they are a VIP member at which point they can be bought or sold."
 address: "EQDZdhm1yVVKmhGeLxZSkPi3HTvZqjGNnImsNXdwcRiaqkwi"
-homepage: "https://www.bluejaygames.com"
-community: "https://t.me/BjGCommunity"
-social: "https://x.com/BlueJayGamesInc"

--- a/jettons/BjGTapperCollectibles.yaml
+++ b/jettons/BjGTapperCollectibles.yaml
@@ -1,3 +1,0 @@
-name: "BjG Tapper Collectibles"
-description: "These NFTs are created by users in the Telegram Game BjG Tapper. User unveil a new NFT for each unique level and can download those to their wallet if they are a VIP member at which point they can be bought or sold."
-address: "EQDZdhm1yVVKmhGeLxZSkPi3HTvZqjGNnImsNXdwcRiaqkwi"

--- a/jettons/BjGTapperCollectibles.yaml
+++ b/jettons/BjGTapperCollectibles.yaml
@@ -1,0 +1,6 @@
+name: "BjG Tapper Collectibles"
+description: "These NFTs are created by users in the Telegram Game BjG Tapper. User unveil a new NFT for each unique level and can download those to their wallet if they are a VIP member at which point they can be bought or sold."
+address: "EQDZdhm1yVVKmhGeLxZSkPi3HTvZqjGNnImsNXdwcRiaqkwi"
+homepage: "https://www.bluejaygames.com"
+community: "https://t.me/BjGCommunity"
+social: "https://x.com/BlueJayGamesInc"


### PR DESCRIPTION
Added metadata for BjG Tapper Collectibles NFTs including name, description, address, homepage, community, and social links.

Please make sure you change the original .yaml fields in the accounts/, collections/ or jettons/ directories and leave the auto-generated .json files in the repository root alone. Also please make sure that you do not use ton.api links in your pull request.
Example pull request:

```yaml
address: Address of your token 
symbol: Symbol of your token
websites:
  - "link"
social:
  - "link"
```

**ATTENTION! The Tonkeeper team does not charge any fees for checking/verifying tokens/collections. The procedure is ABSOLUTELY FREE. Ignore comments in commits that require payment to speed up/successfully check the PR. Stay safe fren!**

Пожалуйста, убедитесь, что вы изменили исходные поля .yaml в каталогах account/, Collections/ или jettons/ и не трогаете автоматически сгенерированные файлы .json в корне репозитория. Так же, пожалуйста, убедитесь, что вы не используете ссылки ton.api в вашем пул реквесте.
Пример пул реквеста:

```yaml
address: Адрес вашего токена 
symbol: Сивол вашего токена
websites:
  - "ссылка"
social:
  - "ссылка"
  ```

**ВНИМАНИЕ! Команда Tonkeeper не берет никакой оплаты за проверку/верификацию токенов/коллекций. Процедура АБСОЛЮТНО БЕСПЛАТНА. Игнорируйте комментарии в коммитах, требующих оплаты для ускорения/успешности проверки. Будьте внимательны и осторожны!**
