### PR TITLE
Add PDLB (Padel Bot Token) jetton

### DIFF
--- a/jettons/PDLB.yaml
+++ b/jettons/PDLB.yaml
@@ -1,0 +1,8 @@
+name: Padel Bot Token
+symbol: PDLB
+address: EQBSrK7cUdROGDStKkoMyTsDtdgR4me8xctZJkPgt2A7Mtu-
+decimals: 9
+image: "https://api.endpointtools.com/images/pdlb-token.png"
+description: "Utility token for the Padel Tennis Telegram WebApp - a platform for organizing padel tennis games with winning court rotation system."
+social:
+  - "https://t.me/PadelApp24Bot"

--- a/jettons/PDLB.yaml
+++ b/jettons/PDLB.yaml
@@ -1,8 +1,9 @@
 name: Padel Bot Token
-symbol: PDLB
-address: EQBSrK7cUdROGDStKkoMyTsDtdgR4me8xctZJkPgt2A7Mtu-
-decimals: 9
+description: Utility token for the Padel Tennis Telegram WebApp - a platform for organizing padel tennis games with winning court rotation system. Players earn points by participating in games and can claim PDLB tokens as rewards.
 image: "https://api.endpointtools.com/images/pdlb-token.png"
-description: "Utility token for the Padel Tennis Telegram WebApp - a platform for organizing padel tennis games with winning court rotation system."
+address: EQBSrK7cUdROGDStKkoMyTsDtdgR4me8xctZJkPgt2A7Mtu-
+symbol: PDLB
+websites:
+  - "https://tg.endpointtools.com"
 social:
   - "https://t.me/PadelApp24Bot"


### PR DESCRIPTION
## Add PDLB (Padel Bot Token)

- **Name:** Padel Bot Token
- **Symbol:** PDLB
- **Address:** `EQBSrK7cUdROGDStKkoMyTsDtdgR4me8xctZJkPgt2A7Mtu-`
- **Decimals:** 9
- **Image:** https://api.endpointtools.com/images/pdlb-token.png

### About

PDLB is a utility token for the Padel Tennis Telegram WebApp — a platform for organizing padel tennis games with a winning court rotation system. Players earn points by participating in games and can claim PDLB tokens as rewards.

- Telegram Bot: [@PadelApp24Bot](https://t.me/PadelApp24Bot)
- Token deployed via [minter.ton.org](https://minter.ton.org)
- Total supply: 2,000,000,000 PDLB