### PR TITLE
Add Lucky Token (LUCK) jetton

### DIFF
--- a/jettons/LuckyToken.yaml
+++ b/jettons/LuckyToken.yaml
@@ -1,7 +1,7 @@
 name: Lucky Token
 description: "Lucky Token ($LUCK) - Reward token for Lucky Day, a Telegram Mini App game on TON. Earn LUCK through arena competitions and seasonal events."
 image: "https://yourluckyday.app/images/luck-token.png"
-address: EQDu0E2WIw-S2XOVMHN8aM3-joJoPXDRLTsqynRvfXqbmqwp
+address: EQACnReWc17Bd6WqAm6OOB00aZcLKhMgj8s0Yrhooz11yFZ3
 symbol: LUCK
 decimals: 9
 websites:

--- a/jettons/LuckyToken.yaml
+++ b/jettons/LuckyToken.yaml
@@ -1,0 +1,10 @@
+name: Lucky Token
+description: "Lucky Token ($LUCK) - Reward token for Lucky Day, a Telegram Mini App game on TON. Earn LUCK through arena competitions and seasonal events."
+image: "https://yourluckyday.app/images/luck-token.png"
+address: EQDu0E2WIw-S2XOVMHN8aM3-joJoPXDRLTsqynRvfXqbmqwp
+symbol: LUCK
+decimals: 9
+websites:
+  - "https://yourluckyday.app"
+social:
+  - "https://t.me/yourluckyday"


### PR DESCRIPTION
## Summary
- Adding Lucky Token ($LUCK) to the jetton registry
- LUCK is the reward token for Lucky Day, a Telegram Mini App game on TON
- Contract is verified on [verifier.ton.org](https://verifier.ton.org/EQDu0E2WIw-S2XOVMHN8aM3-joJoPXDRLTsqynRvfXqbmqwp)

## Token Details
- **Name**: Lucky Token
- **Symbol**: LUCK
- **Decimals**: 9
- **Total Supply**: 1,000,000,000 (1B, fixed)
- **Minter Address**: `EQDu0E2WIw-S2XOVMHN8aM3-joJoPXDRLTsqynRvfXqbmqwp`
- **Mintable**: false (permanently disabled)
- **Owner**: zero address (renounced)

## Links
- Website: https://yourluckyday.app
- Telegram: https://t.me/yourluckyday
- Tonviewer: https://tonviewer.com/EQDu0E2WIw-S2XOVMHN8aM3-joJoPXDRLTsqynRvfXqbmqwp