### PR TITLE
Add MEDUZA jetton

### DIFF
--- a/jettons/MEDUZA.yaml
+++ b/jettons/MEDUZA.yaml
@@ -1,0 +1,15 @@
+name: "MEDUZA"
+symbol: "MEDUZA"
+address: "EQCpP5G76znZMaCeJ5iZH6Ugi8GOZNWdN0RLmW9Yl346wqDa"
+decimals: 7
+description: "Community-driven token supporting decentralized media on TON"
+image: "https://wjm4lsfc7cebmh6zmcghc7dx2eemdpl6avhbeamx5nriixem4piq.arweave.net/slnFyKL4iBYf2WCMcXx30QjBvX4FThIBl-tihFyM49E/logo.png"
+social:
+  - "https://t.me/meduza_eng"
+  - "https://t.me/meduza_rus"
+  - "https://x.com/meduzacoin"
+  - "https://meduzacoin.ru"
+  - "https://dedust.io/pools/EQAwFWskbWUfjxefx-ey0n3DSkWwmE5EuAE-6n2XnrzAwb33"
+  - "https://dedust.io/pools/EQAyA9xIZqHRPNXp1SqSeAbAoh-MWOnIW2pKb-CX86AfvOMy"
+  - "https://app.ston.fi/pools/EQBT3hnpGDcTdxypNlCXQ1RDDCr37iURa4Bta_M5pvOtJZPd"
+  - "https://app.ston.fi/pools/EQCBtLA-_DSUF0hht0ZQFO38yoDPl-lXA7IbgqFhE-yGV0T5"


### PR DESCRIPTION
Add MEDUZA jetton metadata

This pull request adds metadata for the MEDUZA jetton on the TON blockchain.

Jetton Minter Address:
EQCpP5G76znZMaCeJ5iZH6Ugi8GOZNWdN0RLmW9Yl346wqDa

Metadata (Arweave):
https://arweave.net/gR1xmIO_q23fpCdBOK6kgvzV5CAii_yS41Wz9vrRv94

MEDUZA is a community-driven token inspired by ocean mythology and decentralized media culture. The project focuses on organic community growth and transparent token distribution.

The metadata includes the token name, symbol, decimals, image hosted on Arweave, and links to official resources.

Official links included in metadata:
Telegram (ENG & RUS), X, official website, and liquidity pools on DeDust and STON.fi.

MEDUZA is not an investment product and provides no financial guarantees.


Resubmitting metadata for MEDUZA jetton after corrections.

Thank you for reviewing.