### PR TITLE
Add TONX jetton

### DIFF
--- a/jettons/TONX.yaml
+++ b/jettons/TONX.yaml
@@ -1,0 +1,10 @@
+name: TONX
+description: TONX is the native utility token of the TONPASS exchange, used for governance, staking, and platform fee benefits on the TON blockchain.
+image: "https://raw.githubusercontent.com/zPu2210/tonx-brand/main/logo.png"
+address: EQBFrpdcm73a7c_6bCrcuKBo8JDxeIcMmp7WcOSVafw9b1hc
+symbol: TONX
+websites:
+  - "https://tonpass.io/"
+social:
+  - "https://x.com/TonPassOfficial"
+  - "https://t.me/tonpasswallet"


### PR DESCRIPTION
## TONX Token

**TONX** is the native utility token of the [TONPASS](https://tonpass.io/) exchange on the TON blockchain. Used for governance, staking, and platform fee benefits.

- **Symbol:** TONX
- **Address:** `EQBFrpdcm73a7c_6bCrcuKBo8JDxeIcMmp7WcOSVafw9b1hc`
- **Website:** https://tonpass.io/
- **Twitter:** https://x.com/TonPassOfficial
- **Telegram:** https://t.me/tonpasswallet