### PR TITLE
Add 72H jetton

### DIFF
--- a/jettons/72H.yaml
+++ b/jettons/72H.yaml
@@ -1,0 +1,10 @@
+name: 72H
+description: 72H is the native token of the 72-hour TON game and sale ecosystem.
+image: "https://72h.lol/72h-logo-chaT.png"
+address: 0:ef1347df770bce8482e34492857766c853db791fd6c6dfe48a46276a6af66346
+symbol: 72H
+websites:
+  - "https://72h.lol"
+social:
+  - "https://t.me/the72h"
+  - "https://x.com/taichi2077"


### PR DESCRIPTION
## Summary

Add the 72H jetton metadata entry for Tonkeeper asset verification.

## Jetton

- Name: `72H`
- Symbol: `72H`
- Master address: `EQDvE0ffdwvOhILjRJKFd2bIU9t5H9bG3-SKRidqavZjRsw8`
- Raw address: `0:ef1347df770bce8482e34492857766c853db791fd6c6dfe48a46276a6af66346`
- Decimals: `9`
- Website: `https://72h.lol`
- Telegram: `https://t.me/the72h`
- X: `https://x.com/taichi2077`

## Asset links

- Token metadata JSON: `https://ivory-keen-perch-796.mypinata.cloud/ipfs/bafkreicxqvsbn3vpy3i4f2566e2r3vlhyrhouffw6ybp4ul724w2wi5prm`
- Token image: `https://72h.lol/72h-logo-chaT.png`

## Notes

- The image URL is a direct PNG link.
- The website-hosted PNG is byte-identical to the approved project token icon.
- This PR only adds the source YAML entry and does not modify generated `.json` files.
