### PR TITLE
Add GOMINE jetton

### DIFF
--- a/jettons/GOMINE.yaml
+++ b/jettons/GOMINE.yaml
@@ -1,0 +1,13 @@
+name: GoMine
+symbol: GOMINE
+address: EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v
+decimals: 9
+image: "https://gomine.social/gomine-icon-512.png"
+description: |
+  Mine rewards by completing quests inside Telegram. No airdrop waitlist. Earn today, withdraw from $1.
+websites:
+  - "https://gomine.social"
+social:
+  - "https://twitter.com/GoMineApp"
+  - "https://t.me/GoMineOfficial"
+  - "https://t.me/GoMineCommunity"


### PR DESCRIPTION
Adding GOMINE, a jetton for the GoMine Telegram mini-app (quests → rewards).

**On-chain facts**
- Jetton master: `EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v`
- Fixed supply: 1,000,000,000 (9 decimals)
- Admin revoked (admin cell = `addr_none$00`) — supply permanently locked
- Metadata self-hosted at `https://gomine.social/jetton.json`

**Project**
- Website: https://gomine.social
- App (Telegram): https://t.me/GoMineAppBot/app
- X: https://twitter.com/GoMineApp
- Telegram channel: https://t.me/GoMineOfficial
- Telegram group: https://t.me/GoMineCommunity

**Liquidity**
- STON.fi GOMINE/USDT pool active