### PR TITLE
Add Disvicer (VEND) jetton

### DIFF
--- a/jettons/VEND.yaml
+++ b/jettons/VEND.yaml
@@ -1,0 +1,8 @@
+name: Disvicer
+description: A next-generation Web3-powered merchant network redefining commerce through privacy, seamless user experience, and new financial opportunities for both merchants and shoppers.
+address: 0:6fabebc56f74742158ad19171566a5697784e4b1ab7b21441f5a3eaae88ddbdf
+symbol: VEND
+social:
+  - "https://t.me/disvicer"
+  - "https://t.me/corevice"
+  - "https://t.me/DisvicerXBot"


### PR DESCRIPTION
Adding verification info for the Disvicer (VEND) jetton.

**Project:** Disvicer is a Web3-powered merchant network focused on privacy, seamless UX, and new financial opportunities for merchants and shoppers.

**Token details:**
- Name: Disvicer
- Symbol: VEND
- Contract: `0:6fabebc56f74742158ad19171566a5697784e4b1ab7b21441f5a3eaae88ddbdf`

**Links:**
- Telegram (community): https://t.me/disvicer
- Telegram (Corevice): https://t.me/corevice
- Telegram (bot): https://t.me/DisvicerXBot

I've added `jettons/VEND.yaml` following the format of existing entries (e.g. FNZ.yaml). No `.json` files were modified. Happy to make any changes the reviewers request.