### PR TITLE
Add TGRAF jetton

### DIFF
--- a/jettons/TGRAF.yaml
+++ b/jettons/TGRAF.yaml
@@ -1,0 +1,10 @@
+name: TGRAF
+symbol: TGRAF
+address: EQCY8Q9LFD0O-MU4RIChegEzFIM197NuZQx9VFwNVgp6_bgD
+image: "https://token.tgraf.io/logo-400.png"
+description: |
+  TGRAF — TON jetton-расписка. 1 TGRAF = 1 ₽. Свободно торгуется на DeDust, обеспечивает учёт долговых обязательств между сторонами в мессенджере So-Messenger.
+websites:
+  - "https://token.tgraf.io"
+social:
+  - "https://t.me/tgraf_io"


### PR DESCRIPTION
Adds TGRAF jetton metadata.

- Master: `EQCY8Q9LFD0O-MU4RIChegEzFIM197NuZQx9VFwNVgp6_bgD`
- Symbol: TGRAF
- Decimals: 9
- Total supply: 1 000 000 000
- Website: https://token.tgraf.io
- DEX: DeDust (TGRAF/USDT pool)
- Pool: `EQCE52fs5muaoXQMUg7yjJ0pryY8MKli39xLrFRqO7cbQiAu`

TGRAF is a TON jetton used as on-chain debt receipt with a fixed peg of 1 TGRAF = 1 RUB. Trades freely on DeDust against USDT.