### PR TITLE
Add 72H jetton

### DIFF
--- a/jettons/72H.yaml
+++ b/jettons/72H.yaml
@@ -1,0 +1,12 @@
+name: "72H"
+description: "72H is a fixed-supply TON Jetton with 100,000,000,000 total supply and no remaining mint authority."
+image: "https://72h.lol/brand/72hours-logo.png"
+address: EQBGIzEDvvKObStrcVb6i5Z1-8uYZYtUrYzF2rFZU7xUAXVg
+symbol: 72H
+decimals: 9
+websites:
+  - "https://72h.lol"
+  - "https://github.com/tii-mom/72h-capital-contracts"
+social:
+  - "https://t.me/the_72h"
+  - "https://x.com/72hour_s"


### PR DESCRIPTION
Adds the 72H mainnet Jetton metadata.

Jetton master: EQBGIzEDvvKObStrcVb6i5Z1-8uYZYtUrYzF2rFZU7xUAXVg
Website: https://72h.lol
Source and deployment evidence: https://github.com/tii-mom/72h-capital-contracts
Public contract JSON: https://72h.lol/contracts/72h-v2-mainnet.json

The Jetton master has fixed supply and no remaining mint authority: total supply 100,000,000,000 72H, mintable=0, admin=null.