### PR TITLE
Add LuneX (LNX) jetton

### DIFF
--- a/jettons/LuneX.yaml
+++ b/jettons/LuneX.yaml
@@ -7,5 +7,5 @@ address: EQAtqo9BjK1GxkFeyLcAshvwIPlSKYQVEp-XarKSeXESlwq9
 websites:
   - https://lunex.network
 social:
-  - https://t.me/LuneXRoverBot
+  - https://t.me/LuneXGameBot
 comment: Official utility token of the LuneX Tap-to-Earn game on TON. Jetton Master is deployed.

--- a/jettons/LuneX.yaml
+++ b/jettons/LuneX.yaml
@@ -1,0 +1,11 @@
+name: LuneX
+symbol: LNX
+description: Utility token of the LuneX Tap-to-Earn game on TON. Tap the moon, raise lunar pets, complete tasks and earn rewards.
+image: https://lunex.network/l.png
+decimals: 9
+address: EQAtqo9BjK1GxkFeyLcAshvwIPlSKYQVEp-XarKSeXESlwq9
+websites:
+  - https://lunex.network
+social:
+  - https://t.me/LuneXRoverBot
+comment: Official utility token of the LuneX Tap-to-Earn game on TON. Jetton Master is deployed.


### PR DESCRIPTION
LuneX Asset Integration

Resubmitting with all previous issues from #5058 resolved. The project is now actively growing and compliant with TON standards.

Key Updates:

Platform Specifics: LuneX is a Telegram Mini App (TMA). It is built to run exclusively within Telegram mobile clients.

User Guidance: The landing page clearly states that access is mobile-only.

Project Traction: We have reached 500+ active users, and LNX transactions are already being processed on-chain.

Adding the official LuneX (LNX) utility token for the LuneX Tap-to-Earn game on TON.

- Jetton Master address: `EQAtqo9BjK1GxkFeyLcAshvwIPlSKYQVEp-XarKSeXESlwq9`
- Website: https://lunex.network
- Telegram bot: https://t.me/LuneXGameBot
- Contract is deployed (jetton_master), visible here: https://tonviewer.com/EQAtqo9BjK1GxkFeyLcAshvwIPlSKYQVEp-XarKSeXESlwq9
- Max supply: 100,000,000,000 LNX

This is a new clean PR after the previous one was closed.
