### PR TITLE
Add TONX (TON Strategy Co) jetton

### DIFF
--- a/jettons/$TONX.yaml
+++ b/jettons/$TONX.yaml
@@ -1,0 +1,6 @@
+name: TON Strategy Co
+symbol: TONX
+address: EQCDDpdx4j8Bhh4DzeWZ3cmZe_ermuvyh0vOsaklOgtJAJyE
+image: "https://img.stonks.cash/bc35a7de-5012-42a0-974e-d9d982b89076.jpg"
+description: |
+  Ton Strategy Co $TONX , the first TON Treasury Company listed on Nasdaq.


### PR DESCRIPTION
## Add TONX Jetton

| Field | Value |
|-------|-------|
| **Name** | TON Strategy Co |
| **Symbol** | TONX |
| **Address** | EQCDDpdx4j8Bhh4DzeWZ3cmZe_ermuvyh0vOsaklOgtJAJyE |
| **Decimals** | 9 |
| **Description** | Ton Strategy Co $TONX , the first TON Treasury Company listed on Nasdaq. |

Adding the TONX jetton to the verified assets list for Tonkeeper.