### PR TITLE
[codex] Add CATNIP jetton metadata

### DIFF
--- a/jettons/CATNIP.yaml
+++ b/jettons/CATNIP.yaml
@@ -1,0 +1,10 @@
+name: "CATNIP"
+description: "CNP combines NFTs, social incentives, and TON blockchain technology to build a decentralized pet content ecosystem."
+symbol: "CNP"
+address: "EQDogVd_JmyuVnrsKbpXyOu-Cs7dmKWgLFOBQaUqoYMtT-xp"
+decimals: "9"
+image: "https://cnp-token-assets.pages.dev/assets/token.png"
+websites:
+  - "https://getgems.io/user/UQDU5RDJxfWVNwPA_DXVUzOUrAt3ByC8VJpSD9IdwQqOSkb3"
+social:
+  - "https://t.me/scaredcat"


### PR DESCRIPTION
## Summary
- Add CATNIP (CNP) jetton metadata to the source `jettons/` list.
- Use a direct PNG image link hosted on Cloudflare Pages instead of a cached image URL.

## Verification
- Verified Jetton Master via TonAPI: `EQDogVd_JmyuVnrsKbpXyOu-Cs7dmKWgLFOBQaUqoYMtT-xp`
- Verified metadata: `name=CATNIP`, `symbol=CNP`, `decimals=9`, `verification=none`
- Verified image URL returns `HTTP 200` with `content-type: image/png`
- Ran read-only schema and duplicate-address validation locally.

## Notes
The image URL is a direct `.png` asset URL and does not use `cache.tonapi.io`.
