### PR TITLE
Add PEPETON jetton

### DIFF
--- a/jettons/PEPETON.yaml
+++ b/jettons/PEPETON.yaml
@@ -1,0 +1,10 @@
+name: PEPETON
+symbol: PEPETON
+description: PEPETON is a TON curve Jetton. TON enters the contract, PEPETON is printed by the curve, and sells burn PEPETON back into the reserve.
+image: "https://www.pepeton.org/pepe-head.png"
+address: EQDyoySuaPkH9-QcYH7TXFNzk8BcZHSlWTkVAGVzS9qWx1_f
+decimals: 9
+websites:
+  - "https://www.pepeton.org"
+social:
+  - "https://t.me/pilethepepe_bot"


### PR DESCRIPTION
Adds PEPETON Jetton metadata.

address: EQDyoySuaPkH9-QcYH7TXFNzk8BcZHSlWTkVAGVzS9qWx1_f
symbol: PEPETON
websites:
  - "https://www.pepeton.org"
social:
  - "https://t.me/pilethepepe_bot"

Metadata: https://www.pepeton.org/pepeton.json
