### PR TITLE
Add TIME jetton

### DIFF
--- a/jettons/TIME.yaml
+++ b/jettons/TIME.yaml
@@ -1,0 +1,4 @@
+name: TIME
+symbol: TIME
+address: EQARuEwjLqa_jsxnjV3cD63e3SkbKbT5eJ7SeI4mYKeeDN43
+decimals: 9


### PR DESCRIPTION
TIME is a TON jetton with deflationary mechanics (1 token/sec burn across all holders) and a 3-level on-chain referral system.

Contract: `EQARuEwjLqa_jsxnjV3cD63e3SkbKbT5eJ7SeI4mYKeeDN43`
Decimals: 9
Website: https://memetimeton.fun