### PR TITLE
Update BabyYoda.yaml (Logo + X account)

### DIFF
--- a/jettons/BabyYoda.yaml
+++ b/jettons/BabyYoda.yaml
@@ -1,5 +1,5 @@
 name: Baby Yoda
-image: "https://raw.githubusercontent.com/maxsoloma/images/main/BabyYoda.jpg"
+image: "https://www.babyyoda.lol/assets/hero/BabyYoda.jpg"
 description: Baby Yoda coin was born out of Egor's creativity and the imagination of the Telegram community.  Its arrival resonates deeply with crypto enthusiasts, demonstrating the substantial impact even a modest token could have in the expansive world of blockchain.
 address: 0:bbbee28460b742ef6621516b77014540f8e8bae90d43c531d71fbafaa57695e7
 symbol: Yoda
@@ -7,4 +7,4 @@ websites:
   - "https://babyyoda.lol"
 social:
   - "https://t.me/BabyYodaTONCHAIN"
-  - "https://twitter.com/BabyYodaonton"
+  - "https://x.com/yodaonton"


### PR DESCRIPTION
Updating the Baby Yoda ($YODA) jetton logo & X handle to reflect changes.

Contract address: EQC7vuKEYLdC72YhUWt3AUVA-Oi66Q1DxTHXH7r6pXaV50j7

Context: This token has undergone a community takeover after the original team became inactive. The contract admin is renounced (Owner: Zero Address), so the on-chain metadata cannot be updated, this PR updates the logo and socials displayed via Tonkeeper/Tonviewer to reflect the active community brand.

Active community channels:
- Telegram: https://t.me/BabyYodaTONCHAIN
- X / Twitter: https://x.com/yodaonton  
- Website: https://babyyoda.lol

New image hosted on the project's own domain for durability & verification.

Happy to provide additional verification of community legitimacy if needed.
