### PR TITLE
Add $1 jetton

### DIFF
--- a/jettons/$1.yaml
+++ b/jettons/$1.yaml
@@ -1,0 +1,10 @@
+name: "$1"
+description: "$1 is the native utility token of the ONE Ecosystem, built on the TON blockchain. It is used for governance, voting, and participation in prediction markets within ONE Wallet."
+image: "https://assets.1dollar.day/onedollar-token/onedollar_logo.png"
+address: EQCV2rGE-rCcHaiOgrFuqBt98pcFCZEGm47Zs_3mILO-2hxe
+symbol: "$1"
+websites:
+  - "https://onewallet.store/"
+social:
+  - "https://x.com/one_wallet_"
+  - "https://www.facebook.com/profile.php?id=61589009140069"


### PR DESCRIPTION
## Summary
- Add `$1` jetton metadata under `jettons/$1.yaml`.
- Use the direct project-hosted PNG image URL, not a TonAPI/cache image URL.
- Include official website and social links for ONE Wallet.

## Token details
```yaml
name: "$1"
symbol: "$1"
address: EQCV2rGE-rCcHaiOgrFuqBt98pcFCZEGm47Zs_3mILO-2hxe
websites:
  - "https://onewallet.store/"
social:
  - "https://x.com/one_wallet_"
  - "https://www.facebook.com/profile.php?id=61589009140069"
```

## Checks
- [x] Changed only source YAML under `jettons/`
- [x] Did not modify generated `jettons.json`, `accounts.json`, `collections.json`, or `README.md`
- [x] Image URL is a direct `.png` link and does not use `tonapi`
- [x] No duplicate address found in current repo search