### PR TITLE
Add DEV (Devpool ecosystem)

### DIFF
--- a/jettons/DEV.yaml
+++ b/jettons/DEV.yaml
@@ -1,10 +1,12 @@
 name: Devpool ecosystem
-description: "DEV is the native token of the dev. ecosystem on TON: a Telegram mini-app combining wallet, terminal, launchpad and staking. 1% of every trade is redistributed to DEV holders pro-rata via the reflection pool."
+description: "DEV is the native token of the dev. ecosystem on The Open Network — a full Telegram Mini App combining a non-custodial TON wallet, DEX trading terminal aggregating STON.fi + DeDust + other TON DEXes, a token launchpad with built-in liquidity tools, native TON staking with TON-denominated yields, and an in-app play-to-earn game. DEV unlocks priority features in the app, powers staking rewards, and serves as the governance token of the wider devpool studio building consumer products on TON."
 image: "https://img.stonks.cash/be673055-5d75-428b-9966-21a78991b477.png"
 address: EQBO-9qyzbBssniKGNWepV6b_cbSvMGkRIGV-Z-h_AMG2DSP
 symbol: DEV
 websites:
+  - "https://devtoken.su"
   - "https://dev-ai.su"
+  - "https://devpool.su"
 social:
   - "https://t.me/devtoken_news"
   - "https://t.me/devtokenapp_bot"

--- a/jettons/DEV.yaml
+++ b/jettons/DEV.yaml
@@ -1,0 +1,10 @@
+name: Devpool ecosystem
+description: "DEV is the native token of the dev. ecosystem on TON: a Telegram mini-app combining wallet, terminal, launchpad and staking. 1% of every trade is redistributed to DEV holders pro-rata via the reflection pool."
+image: "https://img.stonks.cash/be673055-5d75-428b-9966-21a78991b477.png"
+address: EQBO-9qyzbBssniKGNWepV6b_cbSvMGkRIGV-Z-h_AMG2DSP
+symbol: DEV
+websites:
+  - "https://dev-ai.su"
+social:
+  - "https://t.me/devtoken_news"
+  - "https://t.me/devtokenapp_bot"

--- a/jettons/DEV.yaml
+++ b/jettons/DEV.yaml
@@ -5,7 +5,6 @@ address: EQBO-9qyzbBssniKGNWepV6b_cbSvMGkRIGV-Z-h_AMG2DSP
 symbol: DEV
 websites:
   - "https://devtoken.su"
-  - "https://dev-ai.su"
   - "https://devpool.su"
 social:
   - "https://t.me/devtoken_news"


### PR DESCRIPTION
﻿Submitting $DEV (Devpool ecosystem) for verification.

## Project

DEV is the native token of the **dev. ecosystem** on TON — a comprehensive Telegram Mini App and a family of consumer products by the devpool studio.

The app at @devtokenapp_bot combines:
- **Non-custodial TON wallet** (multi-wallet, seed-phrase import/export, full Jetton + TON send/receive)
- **DEX trading terminal** aggregating liquidity across STON.fi, DeDust and other TON DEXes through swap.coffee
- **Token launchpad** with built-in pool-creation, mandatory initial liquidity gate, on-chain deploy confirmation, holders/trades analytics, auto-buy & auto-sell rules
- **Native TON staking** with three lockup tiers (2 weeks, 1 month, 3 months) paying yields in real TON
- **In-app play-to-earn game** awarding DEV for skill-based gameplay

## Contract

`EQBO-9qyzbBssniKGNWepV6b_cbSvMGkRIGV-Z-h_AMG2DSP`

Standard TEP-74 jetton, no on-chain transfer tax. 9 decimals. Total supply 100,000,000 DEV.

## On-chain

- Pool: **DEV/TON on DeDust** — `EQATbvqSL0TQmaUVgvQlv6eapV-zbK5WWaUJRoMLxXFyJKVG`
- Holders: 115 (organic, no airdrop)
- Indexed by TonAPI: https://tonapi.io/v2/jettons/EQBO-9qyzbBssniKGNWepV6b_cbSvMGkRIGV-Z-h_AMG2DSP

## Websites

- **https://devtoken.su** — official token site
- **https://devpool.su** — devpool studio (parent organisation building consumer apps on TON)

## Social

- **Telegram channel:** https://t.me/devtoken_news
- **Telegram bot (Mini App entry):** https://t.me/devtokenapp_bot

## Why we're applying

The token is at the core of an actively-used product (wallet, terminal, launchpad, staking, game — all live). We're growing organically, not via airdrop. A verified mark in Tonkeeper will let new users in our launchpad and DEX terminal distinguish the canonical DEV jetton from any future imposters.

Thanks for the review — happy to clarify anything or update the entry as requested.