### PR TITLE
Revert "Create pd.yaml"

### DIFF
--- a/jettons/pd.yaml
+++ b/jettons/pd.yaml
@@ -1,6 +1,0 @@
-name: pd
-symbol: PD
-address: EQBCDdOHy1Ub6gN1OUd2PpJ8yswkzBsVg56Fi9L8PKSlFkdt
-social:
-  - "https://t.me/Pdcommunitychat"
-  - "https://x.com/pdofficialton"


### PR DESCRIPTION
Reverts tonkeeper/ton-assets#5285 

As a community pd - we had a stronger token - but the person who had access to pull & merge verified himself faster - now it seems they have become a slave to pvp even though they are weaker than our token and community and have fewer holders.

https://github.com/tonkeeper/ton-assets/pull/5260