### PR TITLE
Add PIF — Pifagor Fund Share jetton

### DIFF
--- a/jettons/PIF.yaml
+++ b/jettons/PIF.yaml
@@ -1,0 +1,11 @@
+name: Pifagor Fund Share
+symbol: PIF
+address: EQBcixnbSQm8c54vHop6kmuZcMJGAH0sBlWg_a7ySdYvThvG
+decimals: 9
+image: "https://pifagor.fund/pif-logo.png"
+description: |
+  On-chain share token of Pifagor Fund — закрытый криптофонд с активным управлением.
+  Open transfer (TEP-74) jetton. Fund maintains mint/burn authority and per-wallet
+  freeze for compliance. NAV calculated daily based on AUM.
+websites:
+  - "https://pifagor.fund/"


### PR DESCRIPTION
Adding **PIF** — share token of Pifagor Fund.

| Field | Value |
|-------|-------|
| Symbol | PIF |
| Name | Pifagor Fund Share |
| Master address | `EQBcixnbSQm8c54vHop6kmuZcMJGAH0sBlWg_a7ySdYvThvG` |
| Decimals | 9 |
| Logo | https://pifagor.fund/pif-logo.png |
| Website | https://pifagor.fund |

Pifagor Fund — closed crypto-fund with active management. PIF is an open-transfer (TEP-74) jetton representing share in the fund. NAV calculated daily based on AUM. Fund maintains mint/burn authority and per-wallet freeze for compliance (TIP-89-style).

Tonviewer: https://tonviewer.com/EQBcixnbSQm8c54vHop6kmuZcMJGAH0sBlWg_a7ySdYvThvG

Total supply on mainnet: 750,000 PIF (deployer-held treasury), all backed by ~$750K USDT capital.