### PR TITLE
Add $WOMB jetton metadata

### DIFF
--- a/jettons/WOMB.yaml
+++ b/jettons/WOMB.yaml
@@ -1,0 +1,10 @@
+name: $WOMB
+description: The roundest sleepy degen on TON. Fair launch public mint.
+image: "https://wombton.com/images/wombat-mascot.png"
+address: UQC5UMg10mhNDTSu89ekpuw3PAOSdkEbmqAPhCSBtC6qDmyb
+symbol: WOMB
+websites:
+  - "https://wombton.com"
+social:
+  - "https://x.com/wombton"
+  - "https://t.me/wombton"


### PR DESCRIPTION
## What
Add `$WOMB` jetton metadata for Tonkeeper/TON assets verification list.

## Jetton details
- Name: `$WOMB`
- Symbol: `WOMB`
- Address: `UQC5UMg10mhNDTSu89ekpuw3PAOSdkEbmqAPhCSBtC6qDmyb`
- Website: `https://wombton.com`
- Image (direct): `https://wombton.com/images/wombat-mascot.png`
- Social:
  - `https://x.com/wombton`
  - `https://t.me/wombton`

## Notes
- Image URL is a direct PNG link.
- Metadata is already set on-chain and served publicly.
- Please review for inclusion in verified jettons list.