### PR TITLE
Add SCAT metadata for Scared Cats CTO

### DIFF
--- a/jettons/SCAT.yaml
+++ b/jettons/SCAT.yaml
@@ -1,0 +1,8 @@
+name: Scared Cats
+description: Scared Cats is a community-led CTO project on TON, based on the famous Telegram collectible Scared Cats. The project is now managed by the community, with secured official links and updated public metadata.
+address: EQDV0Q8euPPdsxHfaOQAmtdDrh3j5o_odMYIJM4nuiUO6t88
+symbol: SCAT
+image: "https://i.postimg.cc/zXTgSH42/scatcto.avif"
+social:
+  - "https://x.com/Scaredcatcto"
+  - "https://t.me/scaredcatcto"


### PR DESCRIPTION
This Pull Request is submitted by the current CTO/community team of Scared Cats.

We are requesting an update/addition of the public jetton metadata with the ticker changed from SCATS to SCAT, while keeping the same project identity, same community, and same jetton contract.

The previous request was submitted by the former dev/team and does not represent the current CTO/community-led team.

The project is now managed by the community. The official social links are secured and under the control of the current CTO/community team.

This update is intended to make the public metadata cleaner, safer, and consistent across the TON ecosystem.

DeDust has already agreed to update the metadata on their side, and we are contacting other TON ecosystem platforms to keep the information consistent everywhere.

Thank you for reviewing our request.
