### PR TITLE
Add MUSH (Mushroom) jetton

### DIFF
--- a/MUSH.yaml
+++ b/MUSH.yaml
@@ -1,0 +1,9 @@
+  name: Mushroom
+  description: "$MUSH is the fungi token of the MCPedia ecosystem — a meme coin celebrating education and the responsible, legal use of medicinal mushrooms. The fungi counterpart to $CANA, growing in balance like mycelium and root."
+  image: "https://bigpump.fra1.cdn.digitaloceanspaces.com/prod/455d524d_1748358754172_5C24DA10-F38E-42B2-8DDC-4A78E3CE0630.jpeg"
+  address: 0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35
+  symbol: MUSH
+  social:
+    - "https://t.me/mushroomcoinchat"
+    - "https://t.me/mushfoundation"
+    - "https://x.com/themushfam"


### PR DESCRIPTION
Adding verification for the MUSH (Mushroom) jetton.

  File: jettons/MUSH.yaml

  address: 0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35
  symbol: MUSH
  social:
    - "https://t.me/mushroomcoinchat"
    - "https://t.me/mushfoundation"
    - "https://x.com/themushfam"
