### PR TITLE
Add pd metadata for pd CTO

### DIFF
--- a/jettons/pd.yaml
+++ b/jettons/pd.yaml
@@ -1,0 +1,10 @@
+address: 0:4556e13b4584b3977e600a03fc2d4ff3a670529d8b16961f5da08c2c213d340c
+symbol: pd
+name: pd
+description: $pd — inspired by Pavel Durov’s legacy and the Telegram ecosystem. 100+ kids lore
+image: "https://i.ibb.co/yvpBFTd/pdlogo.jpg"
+websites: 
+  - "https://durov-cum.com/"
+social: 
+  - "https://x.com/pdton__"
+  - "https://t.me/pd_communitychat"


### PR DESCRIPTION
This pull request is submitted by the current CTO community team at pd. 

Our token (EQBFVuE7RYSzl35gCgP8LU_zpnBSnYsWlh9doIwsIT00DEMH) is **already verified** in Tonviewer, but currently not present in the jettons/ directory. We are not requesting verification as we are already verified - **we are requesting an update to our jetton metadata.**

We wish to update our public jetton metadata and the token name and symbol from PD to pd (lowercase) in accordance with our current branding. We are keeping the same identity, community and the same jetton contract.

This update is intended to make the public metadata cleaner, safer, and consistent across the TON ecosystem.

The community has also been in contact with the StonksLabs team and they have agreed to change the metadata on their end and instructed us to make the pull request here with the ticker and name update. We have reached out to GeckoTerminal as well, and continuing to reach out to other platforms so that the branding and metadata is consistent everywhere. 

Thank you for reviewing our request.

pd community