### PR TITLE
Add MUSH (Mushroom) Jetton

### DIFF
--- a/jettons/MUSH.yaml
+++ b/jettons/MUSH.yaml
@@ -1,13 +1,14 @@
-name: Mushroom
-description: "If the words 'life, liberty, and the pursuit of happiness' don't include the right to experiment with your own consciousness, then the Declaration of Independence isn't worth the hemp it was written on. Advocating for the 
-legality and education of all psychoactive plants 🌱"
-image: "https://bigpump.fra1.cdn.digitaloceanspaces.com/prod/455d524d_1748358754172_5C24DA10-F38E-42B2-8DDC-4A78E3CE0630.jpeg"
-address: 0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35 
-symbol: MUSH
-decimals: 9
-websites:
-- "https://mcpedia.earth"
-social:
-- "https://t.me/mushroomcoinchat"
-- "https://t.me/mushfoundation"
-- "https://x.com/themushfam"
+ name: Mushroom
+  description: "Advocating for the legality and education of all psychoactive plants. If the words 'life, liberty, and the pursuit of happiness' don't include the right to experiment with your own consciousness, then the Declaration of 
+  Independence isn't worth the hemp it was written on."
+  image: "https://bigpump.fra1.cdn.digitaloceanspaces.com/prod/455d524d_1748358754172_5C24DA10-F38E-42B2-8DDC-4A78E3CE0630.jpeg"
+  address: "0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35"
+  symbol: MUSH
+  decimals: 9
+  websites:
+    - "https://mcpedia.earth"
+  social:
+    - "https://t.me/mushroomcoinchat"
+    - "https://t.me/mushfoundation"
+    - "https://x.com/themushfam"
+

--- a/jettons/MUSH.yaml
+++ b/jettons/MUSH.yaml
@@ -1,0 +1,13 @@
+name: Mushroom
+description: "If the words 'life, liberty, and the pursuit of happiness' don't include the right to experiment with your own consciousness, then the Declaration of Independence isn't worth the hemp it was written on. Advocating for the 
+legality and education of all psychoactive plants 🌱"
+image: "https://bigpump.fra1.cdn.digitaloceanspaces.com/prod/455d524d_1748358754172_5C24DA10-F38E-42B2-8DDC-4A78E3CE0630.jpeg"
+address: 0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35 
+symbol: MUSH
+decimals: 9
+websites:
+- "https://mcpedia.earth"
+social:
+- "https://t.me/mushroomcoinchat"
+- "https://t.me/mushfoundation"
+- "https://x.com/themushfam"

--- a/jettons/MUSHROOM.YAML
+++ b/jettons/MUSHROOM.YAML
@@ -1,0 +1,13 @@
+name: Mushroom
+  description: "If the words 'life, liberty, and the pursuit of happiness' don't include the right to experiment with your own consciousness, then the Declaration of Independence isn't worth the hemp it was written on. Advocating for the 
+  legality and education of all psychoactive plants 🌱"
+  image: "https://bigpump.fra1.cdn.digitaloceanspaces.com/prod/455d524d_1748358754172_5C24DA10-F38E-42B2-8DDC-4A78E3CE0630.jpeg"
+  address: 0:45aed92fdf38ad0695b8a9caf1b04a7f066d4ecb3251277fd0281d6ee70a4e35 
+  symbol: MUSH
+  decimals: 9
+  websites:
+    - "https://mcpedia.earth"
+  social:
+    - "https://t.me/mushroomcoinchat"
+    - "https://t.me/mushfoundation"
+    - "https://x.com/themushfam"


### PR DESCRIPTION
Adds the **MUSH (Mushroom)** jetton — the fungi-side token of MCPedia, a citation-backed educational platform for plant and fungi information. 
### Token
  - **Name / Symbol:** Mushroom (MUSH)
  - **Address:** `EQBFrtkv3zitBpW4qcrxsEp_Bm1OyzJRJ3_QKB1u5wpONeIJ`
  - **Supply:** 1,000,000,000 (non-mintable)
  - **Explorer:** https://tonviewer.com/EQBFrtkv3zitBpW4qcrxsEp_Bm1OyzJRJ3_QKB1u5wpONeIJ

  ### Project
  - **Website:** https://mcpedia.earth
  - $MUSH is the fungi counterpart to **$CANA** (`EQBOC7zL42N5pum3ZkGfwmrEgncOJNVziIT5lvlgb0zdlppI`), which is **already verified in this repo** — same project and team.
  - **Socials:** https://t.me/mushroomcoinchat · https://t.me/mushfoundation · https://x.com/themushfam

  ### Checklist
  - [x] Metadata matches the on-chain jetton (name, symbol, decimals, description)
  - [x] Image is a **direct link to the image file** (`.jpeg`), not a webpage; no `ton.api`
  - [x] No duplicate or offensive content
  - [x] File added under `jettons/` as `MUSH.yaml`
