### PR TITLE
Add Grum (GRUM) jetton

### DIFF
--- a/jettons/GRUM.yaml
+++ b/jettons/GRUM.yaml
@@ -1,0 +1,10 @@
+name: Grum
+symbol: GRUM
+address: EQBOrgO9ctBLKpR0JNhL6ZCdiZhDY2giAczovdxQQDTCEFmp
+image: "https://files.catbox.moe/b8jrs9.jpg"
+description: |
+  Grum ($GRUM) — community meme token on TON.
+websites:
+  - "https://dexscreener.com/ton/EQBOrgO9ctBLKpR0JNhL6ZCdiZhDY2giAczovdxQQDTCEFmp"
+social:
+  - "https://x.com/GrumOgTon"


### PR DESCRIPTION
Add verification for **Grum** ($GRUM) jetton.

- **Address:** `EQBOrgO9ctBLKpR0JNhL6ZCdiZhDY2giAczovdxQQDTCEFmp`
- **Twitter:** https://x.com/GrumOgTon
- Image is a direct .jpg link (not ton.api), single file in jettons/.

Community meme token on TON. Thank you for reviewing.