### PR TITLE
Add GRAMIO jetton

### DIFF
--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -6,5 +6,5 @@ symbol: GRAMIO
 websites:
   - "https://gramio.lol/"
 social:
-  - "https://x.com/crypton_hodl"
+  - "https://x.com/gramio_ton"
   - "https://t.me/gramio_ton_chat"

--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,6 +1,6 @@
 name: Official Gram mascot
 description: Gramio, the mascot of Gram; half gem, half meme, and 100% community.
-image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/gramio-logo.jpg"
+image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg"
 address: EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y
 symbol: GRAMIO
 websites:

--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,0 +1,10 @@
+name: Official Gram mascot
+description: Gramio, the mascot of Gram; half gem, half meme, and 100% community.
+image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/gramio-logo.jpg"
+address: EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y
+symbol: GRAMIO
+websites:
+  - "https://gramio.lol/"
+social:
+  - "https://x.com/crypton_hodl"
+  - "https://t.me/gramio_ton_chat"


### PR DESCRIPTION
Add GRAMIO jetton metadata. Contract: EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y. Image: https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg. Website: https://gramio.lol/. Only jettons/GRAMIO.yaml was added.