### PR TITLE
Update AiTon jetton image

### DIFF
--- a/jettons/AiT.yaml
+++ b/jettons/AiT.yaml
@@ -7,4 +7,4 @@ websites:
 social:
   - "https://t.me/ton4btc"
   - "https://t.me/iAiTon_bot"
-image: "https://i.postimg.cc/ncJ5KD4F/256-251.png"
+image: "https://cdn.jsdelivr.net/gh/2022vg21-ux/aiton-assets@main/brightpng.png"


### PR DESCRIPTION
Update AiTon jetton logo image URL.

The previous image URL from postimg.cc may fail to load in Tonkeeper/Tonviewer.

This PR replaces it with a stable direct PNG URL hosted via GitHub/jsDelivr.

Only jettons/AiT.yaml was changed.
No generated .json files were modified.