### PR TITLE
Add GRAMIO curated metadata

### DIFF
--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,0 +1,10 @@
+name: Official Gram mascot
+description: Gramio, the mascot of Gram; half gem, half meme, and 100% community.
+image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg"
+address: 0:3a6fda7720bc0b91c2a23ab6be05ed578d946d41613930f0698d92edb8647195
+symbol: GRAMIO
+websites:
+  - "https://gramio.lol/"
+social:
+  - "https://x.com/gramio_ton"
+  - "https://t.me/gramio_ton_chat"


### PR DESCRIPTION
GRAMIO is already listed through `jettons/imported_from_dex.yaml`, and TonAPI currently returns `verification: whitelist`. However, Tonkeeper still displays GRAMIO as "Unverified Token" in the app.

Previous PR:
https://github.com/tonkeeper/ton-assets/pull/5477

Contract:
EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y

TonAPI:
https://tonapi.io/v2/jettons/EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y

Screenshot from Tonkeeper:

<img width="420" alt="Tonkeeper showing GRAMIO as Unverified Token" src="https://github.com/user-attachments/assets/e0e454b3-b165-4b8e-aadf-55ab75644006" />

This PR is not a duplicate verification request. It adds a curated `jettons/GRAMIO.yaml` entry so the token has full display metadata that the DEX import does not provide:

- updated logo
- description
- website
- X and Telegram links

Only `jettons/GRAMIO.yaml` is added.

Please review this as a curated metadata/display update for GRAMIO.