### PR TITLE
Update GRAMIO public metadata and community branding

### DIFF
--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,0 +1,10 @@
+name: Official Gram mascot
+description: Gramio, the mascot of Gram; half gem, half meme, and 100% community.
+image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg"
+address: 0:3a6fda7720bc0b91c2a23ab6be05ed578d946d41613930f0698d92edb8647195
+symbol: GRAMIO
+websites:
+  - "https://gramio.lol/"
+social:
+  - "https://x.com/gramio_ton"
+  - "https://t.me/gramio_ton_chat"

--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,5 +1,12 @@
 name: Official Gram mascot
-description: Gramio, the mascot of Gram; half gem, half meme, and 100% community.
+description: |-
+  The blue diamond mascot of the Gram era on TON.
+
+  Gram was the beginning. TON carried the vision. Now the name returns — and Gramio is here to make it legendary!
+
+  Built for the community. Fueled by green candles. Powered by the comeback story of Gram.
+
+  Stay bullish. Stay Gram.
 image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg"
 address: 0:3a6fda7720bc0b91c2a23ab6be05ed578d946d41613930f0698d92edb8647195
 symbol: GRAMIO


### PR DESCRIPTION
This pull request updates the public metadata and community branding for GRAMIO.

Contract:
`EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y`

GRAMIO currently appears through `jettons/imported_from_dex.yaml`. This curated entry adds its current:

- logo
- community description
- website
- X account
- Telegram community

The name, symbol, and jetton contract remain unchanged. This update keeps the public visuals and community links accurate and consistent across the TON ecosystem.

Thank you for reviewing this metadata update.

GRAMIO community