### PR TITLE
Revert KFROG.yaml

### DIFF
--- a/jettons/KFROG.yaml
+++ b/jettons/KFROG.yaml
@@ -1,8 +1,0 @@
-name: "Kissed Frogs"
-description: "Kissed Frogs (KFROG) is a meme coin built on the TON blockchain. Inspired by frogs that dream big after every kiss of luck, KFROG captures the fun, chaotic, and playful spirit of crypto while bringing together a strong and united community."
-image: "https://i.postimg.cc/Y96Sbc8v/512512.png"
-address: "EQCq1SdkDE2P1VWna2NwEDOtdookln25NcIIEb03hbNHwBlH"
-symbol: "KFROG"
-social:
- - "https://t.me/Kissed_Frogs_TON"
- - "https://x.com/KissedFrogsTON"


### PR DESCRIPTION
This asset appears to create confusion with the already established "Kissed Frog" token on TON.

The original Kissed Frog project was launched approximately one year earlier and has an existing holder base, community presence, and trading history #5473 . 

The recently verified "Kissed Frogs" asset uses an almost identical name, which may mislead users into believing it is related to or associated with the original project.

To protect users from potential confusion and to maintain accurate asset verification standards, I believe this verification should be reconsidered. The similarity in naming creates unnecessary ambiguity within the TON ecosystem, especially for users searching for the original Kissed Frog token.

I respectfully request a review of this verification and, if deemed appropriate, a revert of the asset listing to prevent confusion between the established project and the newly added token.

Thank you for your consideration.