### PR TITLE
Update GRAMIO information in Tonkeeper

### DIFF
--- a/jettons/GRAMIO.yaml
+++ b/jettons/GRAMIO.yaml
@@ -1,0 +1,17 @@
+name: Official Gram mascot
+description: |
+  The blue diamond mascot of the Gram era on TON.
+
+  Gram was the beginning. TON carried the vision. Now the name returns — and Gramio is here to make it legendary!
+
+  Built for the community. Fueled by green candles. Powered by the comeback story of Gram.
+
+  Stay bullish. Stay Gram.
+image: "https://raw.githubusercontent.com/basednegan/gramio-logo/main/logo-gramio.jpg"
+address: 0:3a6fda7720bc0b91c2a23ab6be05ed578d946d41613930f0698d92edb8647195
+symbol: GRAMIO
+websites:
+  - "https://gramio.lol/"
+social:
+  - "https://x.com/gramio_ton"
+  - "https://t.me/gramio_ton_chat"

--- a/jettons/imported_from_dex.yaml
+++ b/jettons/imported_from_dex.yaml
@@ -508,9 +508,6 @@
 - address: 0:265c22d037a3dc80a3212bdd7f6c03ea6d2bf2882c38799440212b644a2edf51
   name: Goy Token
   symbol: GOY
-- address: 0:3a6fda7720bc0b91c2a23ab6be05ed578d946d41613930f0698d92edb8647195
-  name: Official Gram mascot
-  symbol: GRAMIO
 - address: 0:3a08e807b3c76bf4497d5ad85d6d7a4af2da07c2463ce35419de3b71b39f5b7b
   name: GRAM SEASON
   symbol: GRAMSEASON


### PR DESCRIPTION
Update GRAMIO information in Tonkeeper.

This PR adds the current public information for GRAMIO:

- updated logo
- updated description
- website
- X account
- Telegram community

Contract:
EQA6b9p3ILwLkcKiOra-Be1XjZRtQWE5MPBpjZLtuGRxlS9Y

DexScreener:
https://dexscreener.com/ton/eqa06n9ugtmhdgcuvj2svz5rjfzkydzgy7wzb0vrxfuabvbc

Current public stats:
- holders: 676
- fixed supply: 1,000,000,000 GRAMIO
- mintable: false
- approx. market cap: $45K
- approx. liquidity: $13.9K
- approx. 24h volume: $31.2K

The goal is to keep GRAMIO’s public information consistent across Tonkeeper, DexScreener, and the TON ecosystem.