### PR TITLE
Add NOT Pepe NOPE jetton

### DIFF
--- a/jettons/NOPE.yaml
+++ b/jettons/NOPE.yaml
@@ -1,0 +1,8 @@
+name: NOT Pepe
+description: Definitely NOT Pepe. Nope.
+address: 0:298d02b5aa967706310231a2b41a4b1e592eea7e7840e585dd3fe60a5242b61e
+symbol: NOPE
+image: "https://notpepe.fun/images/nope-logo.png"
+
+websites:
+  - "https://notpepe.fun"


### PR DESCRIPTION
Requesting asset verification for NOT Pepe (NOPE).

Jetton master:
0:298d02b5aa967706310231a2b41a4b1e592eea7e7840e585dd3fe60a5242b61e

Official links:
Website: https://notpepe.fun
Image: https://notpepe.fun/images/nope-logo.png

This PR adds the NOPE jetton metadata to the jettons directory.