### PR TITLE
add Gram Night ($GN) jetton asset

### DIFF
--- a/jettons/GN.yaml
+++ b/jettons/GN.yaml
@@ -1,0 +1,10 @@
+name: Gram Night
+symbol: GN
+address: 0:3af4c86ef763810ad02c7b44896efdffdd5a62555d74779bcb530ff7060f0cca
+image: "https://i.ibb.co/Sw1ZGsCm/image.png" 
+description: "GN after GM | Deployed from topblast.lol"
+decimals: 9
+
+social:
+  - "https://x.com/gngramnight"
+  - "https://t.me/GNGRAMCTO"

--- a/jettons/GN.yaml
+++ b/jettons/GN.yaml
@@ -8,3 +8,6 @@ decimals: 9
 social:
   - "https://x.com/gngramnight"
   - "https://t.me/GNGRAMCTO"
+
+websites:
+  - "https://www.gramnight.fun"


### PR DESCRIPTION
### Description
$GN is a community-driven project establishing itself as the prominent late-night counterpart to the recent $GM (Gram Morning) token ecosystem trend.

### Asset Specification
* **Token Name:** Gram Night
* **Symbol:** GN
* **Decimals:** 9
* **Jetton Master Address:** `0:3af4c86ef763810ad02c7b44896efdffdd5a62555d74779bcb530ff7060f0cca`
* **File Added:** `GN.yaml`