### PR TITLE
TELE jetton verification and metadata update

### DIFF
--- a/jettons/TELE.yaml
+++ b/jettons/TELE.yaml
@@ -1,4 +1,4 @@
-name: Tele
+name: Telegram
 description: Community token. $TELE is designed to be traded in pair with $GRAM to make TELEGRAM
 address: EQBs9E_mg5ODu0nbX4SmxUBMfyAfK3D9CAkhA-knGjmByOie
 symbol: TELE

--- a/jettons/TELE.yaml
+++ b/jettons/TELE.yaml
@@ -1,0 +1,9 @@
+name: Tele
+description: Community token. $TELE is designed to be traded in pair with $GRAM to make TELEGRAM
+address: EQBs9E_mg5ODu0nbX4SmxUBMfyAfK3D9CAkhA-knGjmByOie
+symbol: TELE
+image: https://raw.githubusercontent.com/xinfectedcow-spec/token_logo/main/logo.png
+
+social:
+  - https://t.me/tele_gramton
+  - https://x.com/teleonton


### PR DESCRIPTION
Jetton verification request and metadata update
This token getting popularity from ton users. We reached 200+ holders, active community. Because we have strong narratives that when TON becomes GRAM, the dex pair will be TELE / GRAM and other. I ask you to support our movement and verify this token. People like this. And our narratives are through the years, not a few days.

Name: Telegram
Symbol: TELE

Jetton master:
EQBs9E_mg5ODu0nbX4SmxUBMfyAfK3D9CAkhA-knGjmByOie

Logo:
https://raw.githubusercontent.com/xinfectedcow-spec/token_logo/main/logo.png

Telegram:
https://t.me/tele_gramton

X:
https://x.com/teleonton

