### PR TITLE
Change ticker from 鸭鸭 to YAYA.yaml & add website

### DIFF
--- a/jettons/YAYA.yaml
+++ b/jettons/YAYA.yaml
@@ -1,0 +1,10 @@
+name: YAYA Token
+description: 鸭鸭 | Yaya — It's a duck. On TON. Memecoin. 没有路线图。没有承诺。只是嘎。No roadmap. No promises. Just quack.
+address: EQDBDVzUfmtS1MRlSPSHDGTlwUoSuTQYBU7Of-4mMV43B8Z_
+symbol: YAYA
+websites:
+  - "https://yayaton.org/"
+
+social:
+  - "https://t.me/yayamemeton"
+  - "https://x.com/YaYaMemeTON"


### PR DESCRIPTION
Dear Tonkeeper Team,

We would like to request a change to the ticker metadata for the 鸭鸭 contract: EQDBDVzUfmtS1MRlSPSHDGTlwUoSuTQYBU7Of-4mMV43B8Z_

from the ticker 鸭鸭 to YAYA
aslo name from 鸭鸭 Token to YAYA Token

as well as adding a website to the metadata: https://yayaton.org/

Reasons for the change:
1. To make it more universal
2. To make it easier to find when searching for the coin
3. An easy-to-remember name

Thank you

Best regards,
Gozo