### PR TITLE
Add Agent Gram (GRAMAR) jetton

### DIFF
--- a/jettons/GRAMAR.yaml
+++ b/jettons/GRAMAR.yaml
@@ -1,0 +1,8 @@
+name: Agent Gram
+description: Agent Gram (GRAMAR) is a spy-themed memecoin on TON — a tuxedo agent watching the charts.
+address: EQAmhi8CMaJjhI6qsfBJq9w_E4bQ9SPI1ck4UyfjfZgceDKj
+symbol: GRAMAR
+image: https://raw.githubusercontent.com/highscrren-dotcom/zu4ik/main/IMG_5574.jpeg
+social:
+  - "https://t.me/Agent00GRAM"
+  - "https://x.com/Agent00Gram"


### PR DESCRIPTION
Adding verification entry for the Agent Gram (GRAMAR) jetton on TON.

- Name: Agent Gram
- Symbol: GRAMAR
- Address: EQAmhi8CMaJjhI6qsfBJq9w_E4bQ9SPI1ck4UyfjfZgceDKj

New file: jettons/GRAMAR.yaml. No auto-generated .json files modified. No duplicate ticker or address in the repo.