### PR TITLE
Update GRAMMING information in Tonkeeper

### DIFF
--- a/jettons/GRAMMING.yaml
+++ b/jettons/GRAMMING.yaml
@@ -1,0 +1,15 @@
+name: Gramming
+description: |
+  Gramming is what happens when memes get paid on the GRAM chain.
+
+  Fast, smooth, and dangerously addictive. One minute you're scrolling, next minute you're fully Gramming.
+
+  No roadmap, no stress, just vibes and velocity.
+
+  Are you Gramming enough?
+image: "https://raw.githubusercontent.com/basednegan/gramming-logo/main/logo-gramming.jpg"
+address: 0:26b1820069d3d0ac49fec19ad12b0aa19d178b0ce78a97d4fbd2e9ae934300d5
+symbol: GRAMMING
+social:
+  - "https://x.com/grammingx"
+  - "https://t.me/gramming_chat"

--- a/jettons/GRAMMING.yaml
+++ b/jettons/GRAMMING.yaml
@@ -1,12 +1,10 @@
 name: Gramming
 description: |
-  Gramming is what happens when memes get paid on the GRAM chain.
+  Gramming — is when you are posting or talking about GRAM.
 
-  Fast, smooth, and dangerously addictive. One minute you're scrolling, next minute you're fully Gramming.
+  If it’s about Gram, it’s being talked about here.
 
-  No roadmap, no stress, just vibes and velocity.
-
-  Are you Gramming enough?
+  Let’s get Gramming ꘜ
 image: "https://raw.githubusercontent.com/basednegan/gramming-logo/main/logo-gramming.jpg"
 address: 0:26b1820069d3d0ac49fec19ad12b0aa19d178b0ce78a97d4fbd2e9ae934300d5
 symbol: GRAMMING

--- a/jettons/GRAMMING.yaml
+++ b/jettons/GRAMMING.yaml
@@ -10,6 +10,8 @@ description: |
 image: "https://raw.githubusercontent.com/basednegan/gramming-logo/main/logo-gramming.jpg"
 address: 0:26b1820069d3d0ac49fec19ad12b0aa19d178b0ce78a97d4fbd2e9ae934300d5
 symbol: GRAMMING
+websites:
+  - "https://gramming.lol/"
 social:
   - "https://x.com/grammingx"
   - "https://t.me/gramming_chat"

--- a/jettons/imported_from_dex.yaml
+++ b/jettons/imported_from_dex.yaml
@@ -526,9 +526,6 @@
 - address: 0:3a947da42809cdd67d6e0d962411467675f084454fabca6feeaf7155f5aec22d
   name: Gram god. In GRAM we trust.
   symbol: GRAMGOD
-- address: 0:26b1820069d3d0ac49fec19ad12b0aa19d178b0ce78a97d4fbd2e9ae934300d5
-  name: gramming
-  symbol: GRAMMING
 - address: 0:3a08e807b3c76bf4497d5ad85d6d7a4af2da07c2463ce35419de3b71b39f5b7b
   name: GRAM SEASON
   symbol: GRAMSEASON


### PR DESCRIPTION
Update GRAMMING information in Tonkeeper.

This PR replaces the automatically imported DEX metadata with the current official public information for GRAMMING:

- updated description
- official logo
- website
- X account
- Telegram community
- removal of the duplicate entry from imported_from_dex.yaml

Contract:
EQAmsYIAadPQrEn-wZrRKwqhnReLDOeKl9T70umuk0MA1ULW

DexScreener:
https://dexscreener.com/ton/eqaxirzcbnetaiwvgwdq7ldy__undg-ssgsnqruam7xwv4hv

The goal is to keep GRAMMING's public information consistent across Tonkeeper, DexScreener, and the TON ecosystem.