### PR TITLE
Add HMDR jetton

### DIFF
--- a/jettons/HMDR.yaml
+++ b/jettons/HMDR.yaml
@@ -1,0 +1,8 @@
+name: "Happy's MANDARIN"
+symbol: "HMDR"
+address: "EQDOdxOGOWXMFhuQNgfQt1rv46c-0mGQtVgYdQZUkBXwNBZW"
+description: "Community token of the Happy's MANDARIN ecosystem on TON. The project features an NFT collection with a dedicated reward fund providing weekly rewards to NFT holders."
+image: "https://i.ibb.co/RTgYBhq7/IMG-20260201-123627-jpg.jpg"
+
+social:
+  - "https://t.me/HappysMANDARIN"


### PR DESCRIPTION
Happy's MANDARIN (HMDR) is a community-driven token on The Open Network (TON).

The project features an NFT collection with a dedicated reward fund providing weekly rewards to NFT holders.

Token Information:
Name: Happy's MANDARIN
Symbol: HMDR
Address: EQDOdxOGOWXMFhuQNgfQt1rv46c-0mGQtVgYdQZUkBXwNBZW

Community:
Telegram: https://t.me/HappysMANDARIN

Thank you for reviewing and verifying HMDR.