### PR TITLE
Add PUBG jetton

### DIFF
--- a/jettons/PUBG.yaml
+++ b/jettons/PUBG.yaml
@@ -1,0 +1,11 @@
+name: PUBG
+description: "$PUBG is the utility token powering PUBGPRO.gg; It serves as the entry key for skill-based PUBG tournaments, the stake for access to higher-prize competitions, and the reward medium for winning players. By holding and staking PUBG, participants unlock premium brackets, earn referral commissions, and join profit-sharing pools."
+image: "https://pubgpro.gg/uploads/pubg-coin.png"
+address: EQBmR1S2TdeCDMl956IxzoZ7IPx4f-D2s6Fj2seoUxRy1dbG
+symbol: PUBG
+websites:
+ - "https://pubgpro.gg"
+social:
+ - "https://t.me/pubgru"
+ - "https://www.twitch.tv/PUBGPROTV"
+ - "https://discord.com/invite/rupubg"


### PR DESCRIPTION
Adding the PUBG jetton (utility token of PUBGPRO.gg).

Address: EQBmR1S2TdeCDMl956IxzoZ7IPx4f-D2s6Fj2seoUxRy1dbG
Symbol: PUBG
Website: https://pubgpro.gg