### PR TITLE
Add GoMine (GOMINE) jetton

### DIFF
--- a/jettons/GOMINE.yaml
+++ b/jettons/GOMINE.yaml
@@ -1,0 +1,13 @@
+name: GoMine
+symbol: GOMINE
+address: EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v
+decimals: 9
+image: "https://gomine.social/gomine-icon-512.png"
+description: |
+  Mine rewards by completing quests inside Telegram. No airdrop waitlist. Earn today, withdraw from $1.
+websites:
+  - "https://gomine.social"
+social:
+  - "https://x.com/GoMineApp"
+  - "https://t.me/GoMineOfficial"
+  - "https://t.me/GoMineCommunity"


### PR DESCRIPTION
Adds the GoMine (GOMINE) jetton.

- Jetton master: `EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v`
- Symbol: GOMINE (9 decimals)
- Matches the on-chain off-chain metadata at https://gomine.social/jetton.json
- Liquidity: GOMINE/USDT pool on STON.fi (live TonAPI rate)
- Website: https://gomine.social
- Telegram: https://t.me/GoMineOfficial, https://t.me/GoMineCommunity
- X: https://x.com/GoMineApp

GoMine is a live Telegram mini app where users earn GOMINE by completing quests and withdraw on-chain. Image is a direct PNG on our own domain (not ton.api).