### PR TITLE
Update ZCAT information in Tonkeeper

### DIFF
--- a/jettons/ZCAT.yaml
+++ b/jettons/ZCAT.yaml
@@ -1,0 +1,13 @@
+name: Egor Zhgun's Cat
+description: |
+  EGOR ZHGUN'S CAT ($ZCAT) is the unmistakable cat drawn by Egor Zhgun more than a decade ago: a simple and expressive creation born from his graphic humor.
+
+  Original post: https://x.com/zhgun/status/4181119561394094081
+image: "https://raw.githubusercontent.com/basednegan/zcat-images/main/zcat-logo.jpg"
+address: EQAmVeWCyPsKzpyy6zE-QzyZ0lH_7sFmmroWVxS0b_fJZ0Fd
+symbol: ZCAT
+websites:
+  - "https://zcat.lol/"
+social:
+  - "https://x.com/ZhgunCat"
+  - "https://t.me/ZhgunCatCTO"


### PR DESCRIPTION
Update ZCAT information in Tonkeeper.

This PR replaces the previous ZCAT contract with the correct jetton master contract and updates the token's public information:

- updated master contract
- updated name
- updated description
- direct logo image
- website
- X account
- Telegram community

Contract:
EQAmVeWCyPsKzpyy6zE-QzyZ0lH_7sFmmroWVxS0b_fJZ0Fd

DexScreener:
https://dexscreener.com/ton/eqamvewcypskzpyy6ze-qzyz0lh_7sfmmrowvxs0b_fjz0fd

The goal is to keep ZCAT's public information consistent across Tonkeeper, DexScreener, and the TON ecosystem.
