### PR TITLE
Add CREUCAT token metadata

### DIFF
--- a/jettons/CREUCAT.yaml
+++ b/jettons/CREUCAT.yaml
@@ -1,0 +1,11 @@
+name: CREUCAT
+symbol: CREUCAT
+address: EQAm2swP08pZ9kMy3WnNxfmw9B5zjWK6IfV06CDL8ydT8cOO
+decimals: 9
+description: "🐱✨ Just a cat. Just Creu.\r\nBuilding, growing, and taking over one meme at a time."
+image: "https://imglink.cc/cdn/X7KznBy6KW.webp"
+websites:
+  - "https://giphy.com/CreuCat"
+social:
+  - "https://t.me/CreuCatGram"
+  - "https://x.com/CreuCatGram"


### PR DESCRIPTION
Add CREUCAT metadata for Tonkeeper.

Jetton master:
EQAm2swP08pZ9kMy3WnNxfmw9B5zjWK6IfV06CDL8ydT8cOO

Metadata included:

- Name: CREUCAT
- Symbol: CREUCAT
- Direct image URL: https://imglink.cc/cdn/X7KznBy6KW.webp
- X: https://x.com/CreuCatGram
- Telegram: https://t.me/CreuCatGram
- Website: https://giphy.com/CreuCat