### PR TITLE
Update GOMINE logo URL (cache-bust to new icon path)

### DIFF
--- a/jettons/GOMINE.yaml
+++ b/jettons/GOMINE.yaml
@@ -2,7 +2,7 @@ name: GoMine
 symbol: GOMINE
 address: EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v
 decimals: 9
-image: "https://gomine.social/gomine-icon-512.png"
+image: "https://gomine.social/gomine-icon-512-v2.png"
 description: |
   Mine rewards by completing quests inside Telegram. No airdrop waitlist. Earn today, withdraw from $1.
 websites:


### PR DESCRIPTION
GOMINE (EQBaSm1kTmke7SD5QNlTGi1qPM8_5lfEhNjk7aB5hJ6w9z0v) is whitelisted and verified (thank you for merging #5717).

We updated our logo, but the previous image file was overwritten in place at the same URL, so the cache.tonapi.io imgproxy cache (keyed on the source URL string) kept serving the old bytes. To bust that cache, this PR points image: at a brand new path:

https://gomine.social/gomine-icon-512-v2.png

This is purely a logo cache fix. Verified status is unchanged (the entry already exists).