### PR TITLE
Update SCAT logo image URL

### DIFF
--- a/jettons/SCAT.yaml
+++ b/jettons/SCAT.yaml
@@ -2,7 +2,7 @@ name: Scared Cats
 description: Scared Cats is a community-led CTO project on TON, based on the famous Telegram collectible Scared Cats. The project is now managed by the community, with secured official links and updated public metadata.
 address: EQDV0Q8euPPdsxHfaOQAmtdDrh3j5o_odMYIJM4nuiUO6t88
 symbol: SCAT
-image: "https://i.postimg.cc/zXTgSH42/scatcto.avif"
+image: "https://i.postimg.cc/nL8PytKT/scatcto.avif"
 social:
   - "https://x.com/Scaredcatcto"
   - "https://t.me/scaredcatcto"


### PR DESCRIPTION
The current SCAT logo image hosting had an issue and the logo stopped displaying correctly.

This PR only updates the SCAT image URL with a new stable direct image link.
All other metadata remains unchanged.

Token: Scared Cats / $SCAT
Change: image URL only