### PR TITLE
Add ZCAT jetton

### DIFF
--- a/jettons/ZCAT.yaml
+++ b/jettons/ZCAT.yaml
@@ -1,0 +1,13 @@
+name: Egor Zhgun's Cat
+description: |
+  EGOR ZHGUN'S CAT ($ZCAT) is the unmistakable cat drawn by Egor Zhgun more than a decade ago: a simple and expressive creation born from his graphic humor.
+
+  Original post: https://x.com/zhgun/status/418111956139409408
+image: "https://raw.githubusercontent.com/basednegan/zcat-images/main/zcat-logo.jpg"
+address: EQAmVeWCyPsKzpyy6zE-QzyZ0lH_7sFmmroWVxS0b_fJZ0Fd
+symbol: ZCAT
+websites:
+  - "https://zcat.lol/"
+social:
+  - "https://x.com/ZhgunCat"
+  - "https://t.me/ZhgunCatCTO"


### PR DESCRIPTION
Adds curated metadata for Egor Zhgun's Cat (ZCAT) in Tonkeeper assets. Includes the correct jetton master contract, token description, direct logo image, website, X account, and Telegram community.

Contract:
EQAmVeWCyPsKzpyy6zE-QzyZ0lH_7sFmmroWVxS0b_fJZ0Fd

DexScreener:
https://dexscreener.com/ton/eqdikgalsd5xpj22y8i4lb74uj5gynqrckzoimjdit_e2hfo