### PR TITLE
Add CHEPE jetton

### DIFF
--- a/jettons/CHEPE.yaml
+++ b/jettons/CHEPE.yaml
@@ -1,0 +1,8 @@
+name: CHEPE
+description: CHEPE is a community meme token on TON.
+image: "https://img.stonks.cash/32c2739e-7151-4ac7-8599-d1c8cd96b26f.png"
+address: EQBxjNmwpTzSMDI6-_X2ad78fwnvZXxdHSzNyx_0wl5n24S5
+symbol: CHEPE
+social:
+  - "https://t.me/chepechat"
+  - "https://x.com/chepetonbot"


### PR DESCRIPTION
Adds token metadata for **CHEPE** jetton.

- **Name / Symbol:** CHEPE
- **Address:** `EQBxjNmwpTzSMDI6-_X2ad78fwnvZXxdHSzNyx_0wl5n24S5` (`0:718cd9b0a53cd230323afbf5f669defc7f09ef657c5d1d2ccdcb1ff4c25e67db`)
- **Decimals:** 9
- **Telegram:** https://t.me/chepechat
- **X:** https://x.com/chepetonbot

Image is a direct `.png` link (not ton.api), per the contribution guidelines. File added under `jettons/` only.