### PR TITLE
Add COCOON jetton

### DIFF
--- a/jettons/COCOON.yaml
+++ b/jettons/COCOON.yaml
@@ -1,0 +1,8 @@
+name: Cocoon
+description: From Pavel Durov's AI vision to a memecoin reality, COCOON is backed by a community that believes in TON and gives their full support to Pavel Durov in the fight for freedom and decentralization.
+image: "https://i.ibb.co/GQxsts78/1000033536-jpg.jpg"
+address: EQBiyZMUXvdnRYFUk3_R5uPdsR2ROI9mes_1S-jL1tIQDhDK
+symbol: COCOON
+social:
+  - "https://t.me/cocoon_moon"
+  - "https://x.com/COCOONONTON"


### PR DESCRIPTION
Adds token metadata for **Cocoon (COCOON)** jetton.

- **Name / Symbol:** Cocoon / COCOON
- **Address:** `EQBiyZMUXvdnRYFUk3_R5uPdsR2ROI9mes_1S-jL1tIQDhDK` (`0:62c993145ef767458154937fd1e6e3ddb11d91388f667acff54be8cbd6d2100e`)
- **Decimals:** 9
- **Telegram:** https://t.me/cocoon_moon
- **X:** https://x.com/COCOONONTON

Image is a direct `.jpg` link (not ton.api), per the contribution guidelines. File added under `jettons/` only.