### PR TITLE
Add GLAME Coin GLM jetton

### DIFF
--- a/jettons/GLM.yaml
+++ b/jettons/GLM.yaml
@@ -1,0 +1,12 @@
+name: GLAME Coin
+description: GLAME club utility token for CryptoGLAME rewards, GLM Store utility and bridge operations with real GLAME loyalty points.
+address: 0:5a1d2c08991065db9ad6802a46d62b3f83f7c1c80b7e753dfa00f2e7cb00bbbf
+symbol: GLM
+decimals: 9
+image: "https://partner.glamejewelry.ru/static/glm_policy/glm-token-icon-v3.png"
+websites:
+  - "https://glamejewelry.ru"
+  - "https://partner.glamejewelry.ru/glm"
+  - "https://partner.glamejewelry.ru/referral"
+social:
+  - "https://t.me/glamejewelry"


### PR DESCRIPTION
# Add GLAME Coin GLM jetton

## Token

- Name: GLAME Coin
- Symbol: GLM
- Decimals: 9
- Mainnet Jetton master: `EQBaHSwImRBl25rWgCpG1is_g_fByAt-dT36APLnywC7v2fl`
- Raw address: `0:5a1d2c08991065db9ad6802a46d62b3f83f7c1c80b7e753dfa00f2e7cb00bbbf`

## Official Links

- Website: https://glamejewelry.ru
- GLM landing: https://partner.glamejewelry.ru/glm
- Partner site: https://partner.glamejewelry.ru/referral
- Metadata: https://partner.glamejewelry.ru/static/glm_policy/jetton-metadata.json
- Icon: https://partner.glamejewelry.ru/static/glm_policy/glm-token-icon-v3.png

## Description

GLM is the GLAME club utility token for CryptoGLAME rewards, GLM Store utility and bridge operations connected with real GLAME loyalty points.

GLM is not positioned as an investment product, stablecoin, deposit, or guaranteed buyback asset. Public policy, risk disclosure and bridge rules are linked from the metadata and GLM landing page.

## Verification Notes

- The token metadata is hosted on the official GLAME partner domain.
- The icon is a 1024x1024 PNG with the GLAME brand sign.
- The initial mainnet bank mint of `10,000,000 GLM` was completed to the GLAME treasury/bank wallet.
