### PR TITLE
Add StarNex (SNX) jetton

### DIFF
--- a/jettons/SNX.yaml
+++ b/jettons/SNX.yaml
@@ -1,0 +1,12 @@
+name: StarNex
+image: "https://files.tgstars.uk/jetton-icon.png"
+description: StarNex (SNX) is the first reward token on its own smart contract in GRAM. Hold SNX in your wallet and receive GRAM rewards.
+address: EQCv6SpGEsC97jBYUkX-rPC8FnvPeJkwhydTVRDzY3QnlsNx
+symbol: SNX
+decimals: 9
+websites:
+  - "https://tgstars.uk/"
+social:
+  - "https://t.me/starnexton"
+  - "https://t.me/lot_tery_bot"
+  - "https://x.com/starnexton"


### PR DESCRIPTION
Adds the StarNex (SNX) jetton.

- Jetton master: `EQCv6SpGEsC97jBYUkX-rPC8FnvPeJkwhydTVRDzY3QnlsNx`
- Symbol: SNX (9 decimals)
- Matches the off-chain metadata at https://files.tgstars.uk/metadata.json
- Liquidity: GRAM/SNX pool on DeDust
- DeDust: https://dedust.io/swap/GRAM/EQCv6SpGEsC97jBYUkX-rPC8FnvPeJkwhydTVRDzY3QnlsNx
- DexScreener: https://dexscreener.com/ton/eqaoyqkj8b-ofsdsllrw-qkuywkdd3mdnfxqhph-v0yf44k7
- Website: https://tgstars.uk/
- Telegram: https://t.me/starnexton
- Bot: https://t.me/lot_tery_bot
- X: https://x.com/starnexton

StarNex is the first reward token on its own smart contract in GRAM. Users simply hold SNX in their wallets to receive GRAM rewards. The image is hosted as a direct PNG on our own domain, and the metadata is hosted on our own infrastructure (not ton.api).