### PR TITLE
Add LulzSec Hacker Collection

### DIFF
--- a/collections/LulzSecHackerCollection.yaml
+++ b/collections/LulzSecHackerCollection.yaml
@@ -3,4 +3,4 @@ description: "An original character study collection for a defensive cybersecuri
 address: EQBPfpzIO3WtqLQgIY8_siIGke6HESmX483NtcQ6Q09jJ0so
 websites:
 - "https://lulzsec.org/nft"
-image: "https://lulzsec.org/nft-assets/collection-logo.png"
+image: "https://lulzsec.org/nft-assets/collection-logo.jpg"

--- a/collections/LulzSecHackerCollection.yaml
+++ b/collections/LulzSecHackerCollection.yaml
@@ -1,0 +1,6 @@
+name: "LulzSec Hacker Collection"
+description: "An original character study collection for a defensive cybersecurity education project, exploring hacker history, technology, and online safety."
+address: EQBPfpzIO3WtqLQgIY8_siIGke6HESmX483NtcQ6Q09jJ0so
+websites:
+- "https://lulzsec.org/nft"
+image: "https://lulzsec.org/nft-assets/collection-logo.png"

--- a/collections/LulzSecHackerCollection.yaml
+++ b/collections/LulzSecHackerCollection.yaml
@@ -1,5 +1,5 @@
 name: "LulzSec Hacker Collection"
-description: "An original character study collection for a defensive cybersecurity education project, exploring hacker history, technology, and online safety."
+description: "A 50-piece original character collection spanning Black Hat, White Hat, FAT HAT HACKERS: SNACK PROTOCOL and FAT HAT HACKERS: HOODIE PROTOCOL, exploring hacker history, technology, defensive security education and playful cyber culture."
 address: EQBPfpzIO3WtqLQgIY8_siIGke6HESmX483NtcQ6Q09jJ0so
 websites:
 - "https://lulzsec.org/nft"


### PR DESCRIPTION
## Summary

- Add the `LulzSec Hacker Collection` to the TON collections source list.
- Use the verified TON mainnet collection address:
  `EQBPfpzIO3WtqLQgIY8_siIGke6HESmX483NtcQ6Q09jJ0so`
- Link the live collection website and a direct collection image URL.

## Verification notes

- The collection is deployed on TON mainnet with 50 original NFTs.
- All 50 items are presented together across four series: Black Hat, White Hat, FAT HAT HACKERS: SNACK PROTOCOL, and FAT HAT HACKERS: HOODIE PROTOCOL.
- The collection website, public metadata, and image URLs were checked over HTTPS.
- The project presents original character art alongside defensive cybersecurity education and playful cyber culture.

Only the source YAML file under `collections/` is changed; generated JSON files are not modified.