### PR TITLE
Add RGNT (Rignite Token) jetton

### DIFF
--- a/jettons/RGNT.yaml
+++ b/jettons/RGNT.yaml
@@ -1,0 +1,4 @@
+symbol: RGNT
+address: EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E
+name: "Rignite Token"
+decimals: 9

--- a/jettons/RGNT.yaml
+++ b/jettons/RGNT.yaml
@@ -1,4 +1,9 @@
+name: Rignite Token
+description: In-game token of Rignite, a tap-to-mine game on Telegram built on TON.
+image: "https://app.rignite.app/icon.png"
+address: "EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E"
 symbol: RGNT
-address: EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E
-name: "Rignite Token"
-decimals: 9
+websites:
+  - "https://rignite.app"
+social:
+  - "https://t.me/RigniteOfficial"


### PR DESCRIPTION
Adding RGNT — Rignite Token, a jetton on TON used in Rignite, a Telegram mini-app mining game (@RigniteBot). Contract EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E, symbol RGNT, decimals 9, fixed supply 100B with minting revoked. It has live on-chain liquidity on STON.fi (RGNT/TON). Website https://app.rignite.app and channel https://t.me/RigniteOfficial. On-chain metadata already includes name, symbol and image. Thanks for reviewing!