### PR TITLE
Add Prism Star (PRISM) jetton

### DIFF
--- a/jettons/PRISM.yaml
+++ b/jettons/PRISM.yaml
@@ -1,0 +1,22 @@
+name: Prism Star
+symbol: PRISM
+description: Utility token for PRISM STAR, a Telegram Mini App collectible card battle game featuring 300+ cards, gacha, progression, equipment, boss battles, seasonal rankings and PRISM RUSH.
+address: EQBeUe1l-2qkBYQGyX_m6VVJ9RalyAcdIdmJNEDX5EIfr8d2
+decimals: 9
+image: https://playprismstar.com/token/logo.png
+
+websites:
+  - https://playprismstar.com
+  - https://playprismstar.com/token
+  - https://playprismstar.com/whitepaper
+
+social:
+  - https://x.com/PlayPrismStar
+  - https://t.me/PrismStarOfficial
+  - https://t.me/PrismStarCommunity
+
+tags:
+  - gamefi
+  - gaming
+  - telegram
+  - miniapp


### PR DESCRIPTION
This pull request adds Prism Star (PRISM) to the TON assets list.

Prism Star is a Telegram Mini App collectible card battle game featuring 300+ collectible cards, gacha, equipment, boss battles, seasonal rankings, and PRISM RUSH.

Official Website:
https://playprismstar.com

Telegram Mini App:
https://t.me/PrismStarGameBot/prismstar

X:
https://x.com/PlayPrismStar

Official Telegram:
https://t.me/PrismStarOfficial

The token has a fixed supply of 1,000,000,000 PRISM, and the admin ownership has been permanently revoked.
Jetton Master:
EQBeUe1l-2qkBYQGyX_m6VVJ9RalyAcdIdmJNEDX5EIfr8d2