### PR TITLE
Add $1 jetton with official Telegram channel

### DIFF
--- a/jettons/$1.yaml
+++ b/jettons/$1.yaml
@@ -1,0 +1,11 @@
+name: "$1"
+description: "$1 is the native utility token of the ONE Ecosystem, built on the TON blockchain. It is used for governance, voting, and participation in prediction markets within ONE Wallet."
+image: "https://assets.1dollar.day/onedollar-token/onedollar_logo.png"
+address: EQCV2rGE-rCcHaiOgrFuqBt98pcFCZEGm47Zs_3mILO-2hxe
+symbol: "$1"
+websites:
+  - "https://onewallet.store/"
+social:
+  - "https://t.me/onedollar_project"
+  - "https://x.com/one_wallet_"
+  - "https://www.facebook.com/profile.php?id=61589009140069"


### PR DESCRIPTION
## Summary
- Add `$1` jetton metadata under `jettons/$1.yaml`.
- Add the official Telegram channel: https://t.me/onedollar_project.
- Keep the direct project-hosted PNG image and official website/social links.

## Context
This is a resubmission of #5254 with new official community evidence. The Telegram channel identifies the project as ONEWALLET, links to https://onewallet.store/, and currently has more than 66,000 subscribers.

## Checks
- [x] Changed only one source YAML file under `jettons/`
- [x] Did not modify generated JSON files or `README.md`
- [x] On-chain name, symbol, description, and image match the submitted metadata
- [x] Image URL is a direct `.png` link and returns HTTP 200
- [x] Website and Telegram channel are reachable
- [x] No duplicate token address exists in the current asset list
