### PR TITLE
Add wVIZ (Wrapped VIZ) jetton

### DIFF
--- a/jettons/wVIZ.yaml
+++ b/jettons/wVIZ.yaml
@@ -1,0 +1,12 @@
+name: "Wrapped VIZ"
+symbol: "wVIZ"
+decimals: 3
+address: "EQAHujyCaWPjfNaAKHSPDlJZJd2mhWl203eLWShz8PM3_VIZ"
+description: "wVIZ is a 1:1 bridge claim on VIZ locked in the viz-gateway multisig. Each wVIZ is redeemable for exactly 1 VIZ on the VIZ blockchain."
+image: "https://raw.githubusercontent.com/viz-cx/viz-gateway/main/metadata/wviz.png"
+websites:
+  - "https://viz.world"
+  - "https://viz.cx"
+social:
+  - "https://t.me/viz_world"
+  - "https://t.me/viz_cx"


### PR DESCRIPTION
Adds `jettons/wVIZ.yaml` for **Wrapped VIZ (wVIZ)**, the bridge token of the [viz-gateway](https://github.com/viz-cx/viz-gateway).

- **Minter:** `EQAHujyCaWPjfNaAKHSPDlJZJd2mhWl203eLWShz8PM3_VIZ`
- **Admin:** a 2-of-3 operator multisig (no single owner) — the token is honestly mintable on each peg-in, backed 1:1 by VIZ locked in the gateway.
- **Decimals:** 3
- **Image:** direct PNG link (no ton.api), served from the project repo.

wVIZ is a 1:1 bridge claim on VIZ locked in the gateway multisig — each wVIZ is redeemable for exactly 1 VIZ on the VIZ blockchain.