### PR TITLE
Add sGRAM (Liquid GRAM) jetton

### DIFF
--- a/jettons/sGRAM.yaml
+++ b/jettons/sGRAM.yaml
@@ -1,0 +1,6 @@
+name: Liquid GRAM
+description: Gram liquid staking token
+address: EQAHWZ7Yjaw99UfZ6NzFL7Ygz_CZRTHSuQxmNnGjTqb2KH1t
+symbol: sGRAM
+websites:
+  - "gram-staking.com"


### PR DESCRIPTION
Adding sGRAM (Liquid GRAM) - liquid staking token for GRAM.

address: EQAHWZ7Yjaw99UfZ6NzFL7Ygz_CZRTHSuQxmNnGjTqb2KH1t
symbol: sGRAM
websites:
  - "https://gram-staking.com"

The jetton is deployed on mainnet. Metadata follows TEP-64.
Tonviewer: https://tonviewer.com/EQAHWZ7Yjaw99UfZ6NzFL7Ygz_CZRTHSuQxmNnGjTqb2KH1t

Only the .yaml file in jettons/ was added  auto-generated .json files untouched.