### PR TITLE
Add MGRMGA jetton

### DIFF
--- a/jettons/MGRMGA.yaml
+++ b/jettons/MGRMGA.yaml
@@ -1,0 +1,8 @@
+name: Make Gram Great Again
+description: "Fully decentralized MEME coin by the GRAM (GRM) community. Make Gram Great Again! Not affiliated with Telegram or TON Foundation."
+address: 0:e7b6133a0e364b22543f950942c2d8fe133d94ad8ce9594578f776dc71ccfe46
+symbol: MGRMGA
+websites:
+  - https://mgrmga.org
+social:
+  - https://t.me/mgrmga_holders


### PR DESCRIPTION
Add MGRMGA (Make Gram Great Again) jetton.

- Token: EQDnthM6DjZLIlQ_lQlCwtj-Ez2UrYzpWUV493bcccz-Rj0c
- Fully decentralized community meme coin on TON.
- Liquidity live on STON.fi, LP locked, admin rights revoked.
- Website: https://mgrmga.org