### PR TITLE
Add Polar Pup (PUP) verified entry

### DIFF
--- a/jettons/$PUP.yaml
+++ b/jettons/$PUP.yaml
@@ -1,0 +1,11 @@
+name: "Polar Pup"
+symbol: "PUP"
+address: "EQAmuf2yZ6vUjhKViYT-IYWNFEgrO3W47o-w9-15q_iD4A5D"
+description: "The internet's most emotional baby seal — drawn by owlhug in 2019 (Telegram sticker contest winner), 3.3M+ pack installs before the coin existed. $PUP on TON."
+
+image: "https://raw.githubusercontent.com/hollowtradr/pup-assets/master/pup_avatar_face_navy.png"
+
+social:
+  - "https://t.me/polarpup"
+  - "https://x.com/PolarPupCoin"
+  - "https://polarpupcoin.com"


### PR DESCRIPTION
Adds a dedicated entry for Polar Pup (PUP), currently listed only via imported_from_dex.yaml.

- Address: `EQAmuf2yZ6vUjhKViYT-IYWNFEgrO3W47o-w9-15q_iD4A5D`
- Verification links: official site https://polarpupcoin.com (lists this CA), X https://x.com/PolarPupCoin, Telegram https://t.me/polarpup — all reference the same address, and the same logo is live on the DexScreener token profile for this CA.
- Logo: updated brand mark (matches DexScreener/X/Telegram) hosted at hollowtradr/pup-assets.
- Note: imported_from_dex.yaml also contains a different token "Polar Seal" using the PUP symbol at another address — this entry is for the token the linked site/socials attest.

Submitted on behalf of the Polar Pup project.