### PR TITLE
Add Satoshi Tribute (SATOSHI) jetton

### DIFF
--- a/jettons/$SATOSHI.yaml
+++ b/jettons/$SATOSHI.yaml
@@ -1,0 +1,5 @@
+name: Satoshi Tribute
+description: A tribute to Satoshi Nakamoto's legacy. Press F and pay your respects to the creator of Bitcoin.
+image: https://chiliec.github.io/Satoshi/newlogo.png
+address: EQCkdx5PSWjj-Bt0X-DRCfNev6ra1NVv9qqcu-W2-SaToSHI
+symbol: SATOSHI


### PR DESCRIPTION
Adds the **Satoshi Tribute** jetton (`SATOSHI`) to `jettons/`.

- **Name:** Satoshi Tribute
- **Symbol:** SATOSHI
- **Address:** [EQCkdx5PSWjj-Bt0X-DRCfNev6ra1NVv9qqcu-W2-SaToSHI](https://tonviewer.com/EQCkdx5PSWjj-Bt0X-DRCfNev6ra1NVv9qqcu-W2-SaToSHI)
- **Image:** direct PNG link (https://chiliec.github.io/Satoshi/newlogo.png)

A tribute to Satoshi Nakamoto. The contract is verified on verifier.ton.org and admin rights have been revoked (owner set to the zero address). Only the `jettons/$SATOSHI.yaml` source file is added; no generated `.json` files were touched.