### PR TITLE
Bump actions/checkout from v3 to v4

### DIFF
--- a/.github/workflows/parse-ton-labels.yml
+++ b/.github/workflows/parse-ton-labels.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install libraries
         run: pip3 install -r requirements.txt
       - name: Run ton-labels-parser

--- a/.github/workflows/rebuild-src.yml
+++ b/.github/workflows/rebuild-src.yml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Install libraries
         run: pip3 install -r requirements.txt
       - name: Run generator.py

--- a/.github/workflows/test_src_valid.yml
+++ b/.github/workflows/test_src_valid.yml
@@ -11,7 +11,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository code
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Check that source dirs contain only *.yaml files
         run: |


### PR DESCRIPTION
Updates `actions/checkout` from **v3** to **v4** across all three workflows:

- `.github/workflows/parse-ton-labels.yml`
- `.github/workflows/rebuild-src.yml`
- `.github/workflows/test_src_valid.yml`

`checkout@v3` runs on the deprecated **Node 16** runtime; **v4** uses **Node 20**. No behavioral change to the workflows otherwise.