### PR TITLE
add new jetton: Farm

### DIFF
--- a/jettons/Farm.yaml
+++ b/jettons/Farm.yaml
@@ -1,0 +1,10 @@
+name: Harvest Finance
+symbol: FARM
+description: "FARM is the official token of FarmTG, a TON-native Telegram mini app that blends social farming, on-chain NFTs, and play-to-earn mechanics."
+image: "https://farm.w.cm/images/farmToken.png"
+decimals: 9
+address: EQBuNmASKhWYel-YYZBdOox7NGA2sx3iQCw_ULOMguevOENF
+websites:
+  - "https://farm.w.cm"
+social:
+  - "https://t.me/farmtg"


### PR DESCRIPTION
Please add FARM to the Tonkeeper token repository. This addition will improve token visibility and user accessibility, helping us further develop and expand the FARM ecosystem within the TON community. Thank you for your support.

name: Harvest Finance
symbol: FARM
description: "FARM is the official token of FarmTG, a TON-native Telegram mini app that blends social farming, on-chain NFTs, and play-to-earn mechanics."
image: "https://farm.w.cm/images/farmToken.png"
decimals: 9
address: EQBuNmASKhWYel-YYZBdOox7NGA2sx3iQCw_ULOMguevOENF
websites:

"https://farm.w.cm/"
social:
"https://t.me/farmtg"