### PR TITLE
Add PYONYA jetton entry

### DIFF
--- a/jettons/PYONYA-TON.yaml
+++ b/jettons/PYONYA-TON.yaml
@@ -1,0 +1,12 @@
+name: Durovs Dog
+description: "Durov's dog. Durov's stickers. Durov's chain. The most Telegram-native memecoin in existence. Oh, and the fluffiest. #LOVEPYONYA"
+address: 0:0ec9fe27fbbc13b53238e4b190c1f69c11f9e4a4e6bdbfa6e3a7081e0875f959
+symbol: PYONYA
+image: https://raw.githubusercontent.com/forrest370-code/pyonya-assets/main/pyonya-256.png
+websites:
+  - "https://pyonya.com"
+social:
+  - "https://t.me/PYONYATON"
+  - "https://x.com/PYONYATON"
+  - "https://www.instagram.com/pyonyaton/"
+  - "https://www.snapchat.com/add/pyonya"


### PR DESCRIPTION
Adds a curated entry for PYONYA, currently present only via DEX
auto-import with no logo.

Contract: EQAOyf4n-7wTtTI45LGQwfacEfnkpOa9v6bjpwgeCHX5WW8y
Raw: 0:0ec9fe27fbbc13b53238e4b190c1f69c11f9e4a4e6bdbfa6e3a7081e0875f959

On-chain metadata contains no image field and the contract is immutable
(mintable: false, no admin), so the logo can only be set here. Logo is a
256x256 PNG over HTTPS, single-hop 200, content-type image/png. Name and
symbol match on-chain metadata exactly. All website and social links
verified resolving.

Note: distinct from the existing jettons/pyonya.yaml (Пёня, EQBKyW3f…),
which is a different jetton. Filename PYONYA-TON.yaml avoids a
case-collision with it. This token is already present in
imported_from_dex.yaml; this PR promotes it to a curated entry solely to
supply the missing logo.
