### PR TITLE
Add RGNT (Rignite Token) jetton

### DIFF
--- a/jettons/RGNT.yaml
+++ b/jettons/RGNT.yaml
@@ -1,0 +1,4 @@
+address: EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E
+name: Rignite Token
+symbol: RGNT
+decimals: 9


### PR DESCRIPTION
Adds `jettons/RGNT.yaml` for Rignite Token (RGNT).

**This is a resubmission.** PR #5799 was closed on 15 Jul 2026 with the note *"We recommend to develop the project further."* That was fair — the project was two days old at the time. Below is what changed in the twelve days since, so the team can judge on current data rather than on the old snapshot.

| | 15 Jul (when #5799 closed) | 27 Jul | |
|---|---|---|---|
| Successful on-chain withdrawals | 68 | 2,160 | 32× |
| Distinct wallets that received RGNT | 23 | 874 | 38× |
| RGNT withdrawn to user wallets | 3,756 | 793,671 | 211× |
| Registered players | 1,960 | 8,616 | 4.4× |

Current holders: 858 (tonapi).

**Token facts**
- Jetton master: [`EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E`](https://tonviewer.com/EQD4s-7jCQ_OBxNMjNagrLO3yFGAKadmwYc2jnpRMw1fcl2E)
- **Ownership renounced** — admin is the zero address, so the supply cannot be increased by anyone
- Metadata is on-chain and complete (name, symbol, 9 decimals, direct image link — no ton.api URL)
- Liquidity: STON.fi TON/RGNT pool, live pricing
- App: https://rignite.app · Channel: https://t.me/RigniteOfficial

**Why verification matters for our users**
RGNT is earned in-app and withdrawn to user wallets. Because the token is unverified, wallets hide or flag it, so players who successfully receive RGNT often cannot see it and conclude the withdrawal failed. We have had to point users to tonviewer to prove funds arrived. Verification would resolve this for a user base that is now in the hundreds of real recipients.

Understood that verification is discretionary and may be declined again. Thank you for reviewing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)