### PR TITLE
Add Beast Seller jetton

### DIFF
--- a/jettons/BeastSeller.yaml
+++ b/jettons/BeastSeller.yaml
@@ -1,0 +1,10 @@
+name: Beast Seller
+description: The beast has entered the market. Beast Seller ($BEAST) lives on TON with a fixed supply of 69,420,000.
+address: EQBMlRRVqsjBe6CrlJBys3j7Zdt43nvtqpQAFSpqGx31EJJQ
+symbol: BEAST
+image: "https://pbs.twimg.com/profile_images/2080124112857382912/l_-pZAzl_400x400.jpg"
+websites:
+  - "https://beastsellerton.com/"
+social:
+  - "https://x.com/BeastSellerTON"
+  - "https://t.me/BeastSellerTON"


### PR DESCRIPTION
Adds the official Beast Seller ($BEAST) jetton on TON.

Jetton address:
EQBMlRRVqsjBe6CrlJBys3j7Zdt43nvtqpQAFSpqGx31EJJQ

Website:
https://beastsellerton.com/

X:
https://x.com/BeastSellerTON

Telegram:
https://t.me/BeastSellerTON
