### PR TITLE
Add metadata for TapTired (TIRED) jetton

### DIFF
--- a/jettons/$TIRED.yaml
+++ b/jettons/$TIRED.yaml
@@ -1,0 +1,4 @@
+name: TapTired
+symbol: TIRED
+decimals: 9
+address: EQCEdnrQns5wXdl1upYykg5Xi6XDSQxLaCP-msz0_4J-6dj

--- a/jettons/$TIRED.yaml
+++ b/jettons/$TIRED.yaml
@@ -1,4 +1,11 @@
-name: TapTired
-symbol: TIRED
+address: "EQCEdnrQns5wXdl1upYykg5Xi6XDSQxLaCP-mszr3_4J-6dj"
+name: "TapTired"
+symbol: "TIRED"
 decimals: 9
-address: EQCEdnrQns5wXdl1upYykg5Xi6XDSQxLaCP-msz0_4J-6dj
+description: "TapTired token official assets."
+image: "https://raw.githubusercontent.com/taptiredofficial-art/TapTiredAssets/main/logo.png"
+websites:
+  - "https://taptired.netlify.app"
+social:
+  - "https://x.com/TapTired"
+  - "https://t.me/taptiredofficial"

--- a/jettons/TGT.yaml
+++ b/jettons/TGT.yaml
@@ -1,0 +1,11 @@
+name: TIRED GAME TOKEN
+description: "Official in-game utility token of the TapTired ecosystem."
+image: "https://raw.githubusercontent.com/taptiredofficial-art/TiredGameTokenAssets/main/logo.png"
+address: "EQB0Gq_deVpXtJoYA9FeckB5K7zSsTKr1QcdZedHypLSeHKa"
+symbol: TGT
+websites:
+  - "https://taptired.netlify.app"
+social:
+  - "https://t.me/taptiredofficial"
+  - "https://x.com/TapTired"
+  - "https://github.com/taptiredofficial-art/TiredGameTokenAssets"


### PR DESCRIPTION
Official metadata for the TapTired (TIRED) jetton.

Jetton master address:
EQCEdnrQns5wXdl1upYykg5Xi6XDSQxLaCP-mszr3_4J-6dj

Website:
https://taptired.netlify.app

X:
https://x.com/TapTired

Telegram:
https://t.me/taptiredofficial