### PR TITLE
Add Avex (AX) jetton

### DIFF
--- a/jettons/AX.yaml
+++ b/jettons/AX.yaml
@@ -1,0 +1,4 @@
+name: Avex
+symbol: AX
+address: EQAh8m_BDCcaeiRoK7UovXJMLsq0P2if-JkpCkOBHw4rZYXb
+decimals: 9


### PR DESCRIPTION
### Jetton

- **Name:** Avex
- **Symbol:** AX
- **Address:** EQAh8m_BDCcaeiRoK7UovXJMLsq0P2if-JkpCkOBHw4rZYXb
- **Decimals:** 9

Avex (AX) is the in-app utility token of Prediction Arena, a Telegram Mini App.

The contract was deployed unmodified from the official `ton-blockchain/acton`
jetton template (Jetton 2.0 reference implementation), so it is TEP-74 and
TEP-64 compliant. Metadata is stored fully on-chain.

### Additional request

TonAPI currently returns `verification: blacklist` for this jetton, which
surfaces as SCAM / FAKE labels in Tonviewer and Tonkeeper.

I checked the public `tonkeeper/scam_backoffice_rules` and none of its patterns
match this token's symbol, name, description or image, so this looks like a
false positive rather than a metadata problem.

Could you clarify what triggered the blacklist status and whitelist the token?
I'm happy to correct anything on my side — admin rights have deliberately not
been revoked yet, so on-chain metadata can still be fixed if needed.