### PR TITLE
Add Kridder (KRID) jetton

### DIFF
--- a/jettons/KRID.yaml
+++ b/jettons/KRID.yaml
@@ -1,6 +1,6 @@
 name: Kridder
 description: Kridder crashed out. His aura kicked rocks.
-address: EQDQcGbfGAFf5jKvXHspZTuBaH2sqsYWR-djQZfmEcG18_-l
+address: EQCzrzXy-CRTA6-A_WMgWaRjCu8xvS9SW7AhiwvavxLBfvHP
 symbol: KRID
 image: "https://raw.githubusercontent.com/moistlog01-arch/kridder-ton/main/D%20Kridder.png"
 websites:

--- a/jettons/KRID.yaml
+++ b/jettons/KRID.yaml
@@ -1,0 +1,9 @@
+name: Kridder
+description: Kridder crashed out. His aura kicked rocks.
+address: EQDQcGbfGAFf5jKvXHspZTuBaH2sqsYWR-djQZfmEcG18_-l
+symbol: KRID
+image: "https://raw.githubusercontent.com/moistlog01-arch/kridder-ton/main/D%20Kridder.png"
+websites:
+  - "https://github.com/moistlog01-arch/kridder-ton"
+social:
+  - "https://t.me/DerekKridderTON"


### PR DESCRIPTION
Adds Kridder (KRID) on TON.

Jetton master:
EQCzrzXy-CRTA6-A_WMgWaRjCu8xvS9SW7AhiwvavxLBfvHP

Fixed supply: 1,000,000,000 KRID
Decimals: 9
Minting permanently disabled
Admin locked to the unspendable TON zero address

The earlier deployment was retired and its entire supply was burned to zero before this address was submitted.
