### PR TITLE
Create ARL.yaml

### DIFF
--- a/jettons/ARL.yaml
+++ b/jettons/ARL.yaml
@@ -1,0 +1,9 @@
+name: AEROAL
+description: AEROAL token on TON.
+address: EQAAhMn_aDKvXAzGjcBlSQW4cL4ZItvdlHnr6McuZnLd5Z7u
+symbol: ARL
+decimals: 9
+image: "https://aeroalaero.com/ARLtoken.png"
+websites:
+  - "https://aeroalaero.com"
+  - "https://crypto.aeroalaero.com"


### PR DESCRIPTION
Add AEROAL ARL jetton

Adds AEROAL (ARL) Jetton metadata for Tonkeeper verification.

address: EQAAhMn_aDKvXAzGjcBlSQW4cL4ZItvdlHnr6McuZnLd5Z7u
symbol: ARL
websites:
- "https://crypto.aeroalaero.com"

Logo: https://aeroalaero.com/ARLtoken.png

Only jettons/ARL.yaml was added. No auto-generated .json files were changed.
