### PR TITLE
Add GOYIM jetton

### DIFF
--- a/jettons/GOYIM.yaml
+++ b/jettons/GOYIM.yaml
@@ -1,0 +1,7 @@
+name: Goyim
+description: Backed by Big Yahu himself
+image: "https://openverse.me/goyim.png"
+address: EQCGm4ThJUFDYHdQip0fZcxckUNYY2kww6M3T45WEz0ZKhc1
+symbol: GOYIM
+websites: []
+social: []


### PR DESCRIPTION
Adds the GOYIM jetton to the Tonkeeper asset inventory.

Address: EQCGm4ThJUFDYHdQip0fZcxckUNYY2kww6M3T45WEz0ZKhc1
Symbol: GOYIM
Websites: none provided
Social: none provided

The YAML metadata and image URL match the deployed jetton metadata.