### PR TITLE
Add Baby Ladyverse NFT collection

### DIFF
--- a/collections/BabyLadyverse.yaml
+++ b/collections/BabyLadyverse.yaml
@@ -1,0 +1,11 @@
+name: Baby Ladyverse
+address: EQDRRW62k78qk38GVMrUiNIQX3j8_-QDhFWNlzrc_GvxMegl
+social:
+  - "https://t.me/BabyLadyTONCoin"
+  - "https://t.me/BabyLadyOfficial"
+  - "https://x.com/BabyLadyMemes"
+  - "https://hive.blog/@babylady"
+  - "https://www.tiktok.com/@babyladymemes"
+  - "https://youtube.com/@babylady-h7s1x"
+websites:
+  - "https://bbladycto.com/"


### PR DESCRIPTION
Adds the Baby Ladyverse NFT collection to the collections directory.
Collection: Baby Ladyverse
Official website: bbladycto.com
Includes official Baby Lady social/community links.