### PR TITLE
Add TCULT jetton metadata

### DIFF
--- a/jettons/TCULT.yaml
+++ b/jettons/TCULT.yaml
@@ -1,0 +1,10 @@
+name: "TON CULT"
+symbol: "TCULT"
+address: "EQBbuFW3-zTqkL3ZMuVPVqGWOMHqh8e-uEfPDISDNpNouhBY"
+description: "$TCULT is a TON-native, Telegram-first community of original plush characters, games, collectibles, and shared lore."
+image: "https://www.tcult.site/assets/optimized/favicon-256.png"
+social:
+  - "https://t.me/TCULT_GROUP"
+  - "https://x.com/TCULTonTON"
+websites:
+  - "https://www.tcult.site/"


### PR DESCRIPTION
## Summary

Adds the canonical metadata for TON CULT (`TCULT`) to the Tonkeeper jetton registry.

## Metadata

```yaml
address: "EQBbuFW3-zTqkL3ZMuVPVqGWOMHqh8e-uEfPDISDNpNouhBY"
symbol: "TCULT"
websites:
  - "https://www.tcult.site/"
social:
  - "https://t.me/TCULT_GROUP"
  - "https://x.com/TCULTonTON"
```

The image URL is a direct PNG link and does not use `ton.api`.

## Validation

- Tonkeeper repository generator completed successfully with Python UTF-8 mode, matching the repository's Ubuntu CI environment.
- The exact contract and `TCULT` ticker were absent from the current repository and existing pull requests before submission.
- The image URL returned `200`, `image/png`, and the expected 256 by 256 approved asset.
- Only `jettons/TCULT.yaml` is changed. No generated JSON files are included.
