### PR TITLE
Fix RICA image URL

### DIFF
--- a/jettons/RICA.yaml
+++ b/jettons/RICA.yaml
@@ -1,9 +1,9 @@
 name: Rica on Ton
 description: Community-supported TON token inspired by the Rica the Pirate Telegram sticker character.
-image: https://raw.githubusercontent.com/RafaelGomez2099/ton-assets/main/jettons/rica-1.png
+image: https://raw.githubusercontent.com/RafaelGomez2099/rica-assets/main/rica.png
 address: EQBTZvXXSb8JJydzHs349iAbtPORZvyIqvyesCsOQ7rYmg_n
 symbol: RICA
-decimals: 9
+decimals: 9 
 social:
   - https://t.me/rica_the_pirate_cto
   - https://x.com/RicaThePirate


### PR DESCRIPTION
Fixes the RICA image URL after the previous image file was removed from the jettons directory as requested by the maintainer.

The image is now hosted externally and RICA.yaml points to the direct public PNG URL.

No other RICA metadata has been changed.