### PR TITLE
Add $TCULT V2 jetton metadata

### DIFF
--- a/jettons/TCULT.yaml
+++ b/jettons/TCULT.yaml
@@ -1,0 +1,11 @@
+name: "TON CULT"
+description: "$TCULT on TON."
+image: "https://www.tcult.site/assets/optimized/favicon-256.png"
+address: "EQBbuFW3-zTqkL3ZMuVPVqGWOMHqh8e-uEfPDISDNpNouhBY"
+symbol: "TCULT"
+decimals: 9
+websites:
+  - "https://tcult.site/"
+social:
+  - "https://t.me/TCULT_GROUP"
+  - "https://x.com/TCULTonTON"


### PR DESCRIPTION
## Summary

Add the official `$TCULT` V2 jetton on TON mainnet.

## Jetton

- Name: `TON CULT`
- Symbol: `TCULT`
- Address: `EQBbuFW3-zTqkL3ZMuVPVqGWOMHqh8e-uEfPDISDNpNouhBY`
- Decimals: `9`
- Website: `https://tcult.site/`
- Telegram: `https://t.me/TCULT_GROUP`
- X: `https://x.com/TCULTonTON`
- Direct image: `https://www.tcult.site/assets/optimized/favicon-256.png`

## Validation

- The address is a live TON mainnet jetton master.
- Name, symbol, decimals, description, and image match the current on-chain metadata.
- The official website displays the same V2 contract address.
- The website, Telegram group, X profile, and direct PNG resolve.
- The address is not already present in the current `tonkeeper/ton-assets` main branch.
- Only `jettons/TCULT.yaml` is included in this contribution.

Developed by CryptoChucker.
