### PR TITLE
Add DedustFund (DEDUSTFUND)

### DIFF
--- a/jettons/DEDUSTFUND.yaml
+++ b/jettons/DEDUSTFUND.yaml
@@ -1,0 +1,6 @@
+name: DedustFund
+description: Community-driven TON token associated with the DeDust ecosystem.
+image: https://raw.githubusercontent.com/BabyLadyCTO/dedustfund-assets/main/dedust_fund_improved_icon_real.png
+address: EQAmnA14XeBqTRHUqRlaqs_PPAtxBa-HI2d9oqHzdzAaMNUG
+symbol: DEDUSTFUND
+decimals: 9


### PR DESCRIPTION
This PR adds DedustFund (DEDUSTFUND) to TON Assets.

Jetton master:
EQAmnA14XeBqTRHUqRlaqs_PPAtxBa-HI2d9oqHzdzAaMNUG

This submission adds the token metadata and updated project image so the correct DedustFund information can be displayed in Tonkeeper.

Image:
https://raw.githubusercontent.com/BabyLadyCTO/dedustfund-assets/main/dedust_fund_improved_icon_real.png

Symbol: DEDUSTFUND
Decimals: 9