### PR TITLE
Add PLATHO token configuration

### DIFF
--- a/jettons/ATH.yaml
+++ b/jettons/ATH.yaml
@@ -1,0 +1,8 @@
+name: PLATHO
+symbol: "ATH"
+description: "The utility token of Platho — a fully decentralized, post-quantum encrypted messenger that lives entirely on the TON blockchain (no backend, no servers, your keys). Earn ATH as an activity bonus for using the app, and spend it to reduce messaging fees, mint .ath usernames, and attach avatars — all on-chain."
+address: EQCThzitzPXm2dH9psaVkZlkAcHqzCJjcBpD29b5closNeq-
+decimals: 9
+image: "https://i.postimg.cc/NMsNyCwb/jetton.webp"
+websites:
+  - "https://platho.app/"

--- a/jettons/ATH.yaml
+++ b/jettons/ATH.yaml
@@ -6,3 +6,4 @@ decimals: 9
 image: "https://i.postimg.cc/NMsNyCwb/jetton.webp"
 websites:
   - "https://platho.app/"
+  - "https://getgems.io/platho"


### PR DESCRIPTION
This PR adds the token configuration for ATH – the utility token of **Platho**, a fully decentralized, post-quantum encrypted messenger on TON (no backend, no servers). The token is used for fee discounts, .ath username minting, and avatar attachments.
On-chain proof of relevance: **Pavel Durov** has interacted with the messenger (see [transaction](https://tonviewer.com/transaction/ac24fedd54859cab85b6242ced3682ce06d49dfff9e1c0dff06c44ce2ed6920d)).