### PR TITLE
Add Stellarium Worlds NFT collection (live Telegram game, 4,935 players)

### DIFF
--- a/collections/StellariumWorlds.yaml
+++ b/collections/StellariumWorlds.yaml
@@ -1,0 +1,9 @@
+name: "Stellarium Worlds"
+description: "Planets from Stellarium, a Telegram Mini App game. Each NFT is a planet a player owns and plays with in the game — it has rarity, genes, a level and a production rate, and it keeps developing after it is minted or bought."
+image: "https://s.getgems.io/nft/b/c/6a72eff8759f2ee050935d1d/edit/images/1953238.jpg"
+address: EQCb_Q9l6WJMAEPIDjZ3pxMp0PUV9vQLzvFxVS55Z3ATTbbJ
+websites:
+- "https://memetimeton.fun/"
+social:
+- "https://t.me/Timegalaxy_bot"
+- "https://t.me/time_meme_chat"


### PR DESCRIPTION
Hello, and thank you for the work you do maintaining this list.

We would like to submit the **Stellarium Worlds** NFT collection for review. We have submitted before and were declined, and we fully respect that decision. We are coming back now because what we are submitting is genuinely different from last time: the earlier requests were for a small pre-launch collection with almost no usage behind it. Since then the game has actually launched, and the planets are now a working part of it.

### What Stellarium is

Stellarium is a Telegram Mini App game — https://t.me/Timegalaxy_bot. Players collect planets, develop them, and earn in-game currency from them. A planet is not a picture: it has a rarity, a set of genes, a level, an energy cycle and a production rate, and it keeps developing inside the game after it is minted. Minting a planet as an NFT is what lets a player truly own it and sell it to another player.

### Live numbers (2026-08-21)

| | |
|---|---|
| Registered players | **4,935** (first player 2026-05-30) |
| Active in the last 30 days | **3,107** |
| Active in the last 7 days | 368 |
| Players who own at least one planet | **2,590** |
| Players with a connected TON wallet | **1,058** |
| Planets in the game | 3,691 |
| Planets minted as NFT | **1,101** |
| Items on-chain in this collection | **896** (common 367 · uncommon 251 · rare 189 · epic 77 · legendary 12) |
| Collection deployed | 2026-08-07, minting active daily since |

### Where the planets are traded

All secondary trading of planets happens on **Getgems**: https://getgems.io/collection/EQCb_Q9l6WJMAEPIDjZ3pxMp0PUV9vQLzvFxVS55Z3ATTbbJ

This is a deliberate rule on our side, not a coincidence — we do not run our own peer-to-peer planet market, and our community moderator actively blocks direct OTC planet deals in our chat, because an escrowed marketplace is safer for both sides. Getgems is the only venue we point players to.

### Why we are asking

TonAPI currently returns a negative trust value for effectively the whole collection: of 897 items we sampled, **867 are `"trust": "blacklist"` and 30 are `"graylist"`, with none clean**. The collection itself is `"trust": "none"` with `approved_by: []`.

The practical result is that a player who pays for a planet on Getgems, or mints one from inside the game to their own wallet, opens Tonkeeper and sees it flagged as suspicious. Several of them have written to our support asking whether they have been scammed. These are ordinary paid purchases by real players — there is no airdrop to random wallets, no unsolicited distribution, and no investment claim attached to the NFT.

### Collection details

- **Collection:** `EQCb_Q9l6WJMAEPIDjZ3pxMp0PUV9vQLzvFxVS55Z3ATTbbJ` — [tonviewer](https://tonviewer.com/EQCb_Q9l6WJMAEPIDjZ3pxMp0PUV9vQLzvFxVS55Z3ATTbbJ) · [getgems](https://getgems.io/collection/EQCb_Q9l6WJMAEPIDjZ3pxMp0PUV9vQLzvFxVS55Z3ATTbbJ)
- **Owner wallet:** `stellarium.ton` — `0:fa719c64d1066c810c3cd409189b85a2c6c16583954c176e5723df6677a18fc6`
- **Game:** https://t.me/Timegalaxy_bot
- **Website:** https://memetimeton.fun/
- **Community:** https://t.me/time_meme_chat

We are happy to prove ownership of `stellarium.ton` by an on-chain message, a DNS record, or an announcement from the project channel — whatever is most convenient for you.

We understand your rules are strict and that a review takes time. We would be very grateful if this one could be looked at soon, since every day it stays flagged means more paying players being told their purchase looks like a scam. And if the collection does not meet the bar for the whitelist, we would still be thankful for any hint about the `trust: blacklist` classification itself, as that appears to be a separate signal and it is what actually surfaces the warning to holders.

Thank you for your time.

_This replaces our earlier #5956, which contained the same entry without any of this context; closing that one now to avoid a duplicate._