### PR TITLE
Add MemberRewards Genesis collection to whitelist (false-positive scam flag)

### DIFF
--- a/collections/MemberRewards Genesis.yaml
+++ b/collections/MemberRewards Genesis.yaml
@@ -1,0 +1,8 @@
+name: "MemberRewards Genesis"
+address: "EQDSoIlm50Hrl3m18FtBQRMESf4Gt3DT5aD4SYf7pwSUjZwU"
+description: "Founding membership collection of the MemberRewards influencer-marketing platform on TON."
+image: "https://nft.memberrewards.pro/assets/nft-cover.png"
+websites:
+  - "https://memberrewards.pro/"
+social:
+  - "https://t.me/MemberRewardsBot"


### PR DESCRIPTION
Please whitelist the MemberRewards Genesis NFT collection.

Address: EQDSoIlm50Hrl3m18FtBQRMESf4Gt3DT5aD4SYf7pwSUjZwU

It is the founding membership collection of MemberRewards, a live
influencer-marketing platform on TON (https://memberrewards.pro).
The collection is currently marked as "scam" (trust: blacklist) by
mistake — it is a legitimate, self-issued collection held by real
platform users, not an unsolicited airdrop.

Metadata is self-hosted and stable at
https://nft.memberrewards.pro/api/nft/meta/collection.json
Please also remove the blacklist/scam flag from the collection and its items.

Thank you.
