### PR TITLE
add Margcoin Genesis NFT collection

### DIFF
--- a/collections/MargcoinGenesis.yaml
+++ b/collections/MargcoinGenesis.yaml
@@ -1,0 +1,11 @@
+name: "Margcoin Genesis"
+description: "The official Margcoin Genesis NFT Collection on the TON Blockchain. Limited to 4,999 unique NFTs, this collection represents Margcoin’s first on-chain digital collectible and the beginning of its NFT ecosystem."
+address: "EQB8yP1M9jySspeB49molJVnI5tGK5sKm-rvtUzFSyN1faDD"
+websites:
+- "https://app.margcoin.fun"
+social:
+- "https://x.com/MargcoinOG"
+- "https://t.me/MargcoinOG"
+- "https://t.me/MargcoinOGBot"
+- "https://t.me/Margcoin_Chat"
+image: "https://raw.githubusercontent.com/alex-dev-create/MARGCOIN/main/Margcoin%20Genesis%20Statics%20NFT%20Image%20.webp"


### PR DESCRIPTION
This PR adds the Margcoin Genesis NFT collection to the ton-assets registry for official Tonkeeper verification.

Collection Address: EQB8yP1M9jySspeB49molJVnI5tGK5sKm-rvtUzFSyN1faDD