### PR TITLE
Add Crypto Style Profile NFT collection and review false blacklist classification

### DIFF
--- a/collections/CryptoStyle.yaml
+++ b/collections/CryptoStyle.yaml
@@ -1,0 +1,16 @@
+name: "Crypto Style"
+
+description: "Crypto Style Profile Items are utility NFTs used as technical user profiles within the Crypto Style application. Each NFT is created for a registered user and is not distributed randomly. These NFTs are not intended for trading, have no sale mechanics and no royalties. They are application contracts used for user identification and interaction with the Crypto Style smart-contract system."
+
+image: "https://cryptostylematrix.github.io/frontend/cs.png"
+
+address: "EQAiWZqRPp39Z46Y4Pahvj5UQSzafJrUiTbYDcQ0kldLebjn"
+
+social:
+  - "https://crypto-style.org"
+  - "https://cryptostylematrix.github.io/frontend"
+  - "https://t.me/CryptoStyleMatrixNews"
+  - "https://t.me/CryptoStyleMatrixbot"
+  - "https://github.com/cryptostylematrix"
+  - "https://www.youtube.com/@CryptoStyleOfficial"
+  - "https://x.com/CryptoStyleTON"


### PR DESCRIPTION
This pull request adds the Crypto Style Profile NFT collection.

Collection address:
EQAiWZqRPp39Z46Y4Pahvj5UQSzafJrUiTbYDcQ0kldLebjn

Example NFT incorrectly classified as blacklisted:
EQB2S6WT-WbhjcwoepoJ8CFzTR4B9RICUdnJGjXUz71qh5dh

TonAPI currently returns contradictory information for these NFT items:

verified: true
trust: blacklist

Crypto Style Profile Items are technical utility NFT contracts used as user profiles inside the Crypto Style application.

Important details:

- The NFTs are created only for registered users.
- They are not distributed to random wallet addresses.
- They are not promotional airdrops or unsolicited spam.
- They are not intended for trading.
- There are no royalties.
- They do not imitate another NFT collection, token or brand.
- The NFT contracts participate in application operations, which may include receiving and forwarding TON as part of the application's smart-contract logic.
- Similar metadata and images are expected because these are user profile contracts rather than collectible artwork.

The collection contract itself is not marked as scam, and the NFT owners are also not marked as scam. However, most NFT items in the collection have been assigned `trust: blacklist`.

Please review this classification and remove the blacklist status from all NFT items belonging to this collection.

This appears to be a false positive caused by the utility-profile architecture and the number of similar NFT items.