### PR TITLE
Add STURDYSTALLION (SSL) jetton

### DIFF
--- a/jettons/VIMIM.yaml
+++ b/jettons/VIMIM.yaml
@@ -1,0 +1,5 @@
+name: "VIMIM"
+description: "VIMIM is a community-driven token on the TON blockchain."
+image: https://raw.githubusercontent.com/younissafa5555-maker/vimim-assets/main/vimim-vim-logo.jpg
+address: EQAtogKzyv5ITSY_CrRkGmE4FAHAkFLg-s--16rgRksYEKzp
+symbol: "VIM"

--- a/jettons/sturdystallion-ssl.yaml
+++ b/jettons/sturdystallion-ssl.yaml
@@ -1,0 +1,5 @@
+name: STURDYSTALLION
+description: STURDYSTALLION (SSL) on TON
+image: https://raw.githubusercontent.com/doqezila/doqezila-assets/main/sturdystallion-ssl-logo.jpg
+address: EQCB8popfslRemSz6oDGnzL-qPjhgp2IjULxjLyuCNUandhP
+symbol: SSL


### PR DESCRIPTION
Please review STURDYSTALLION (SSL) for the Tonkeeper asset registry. Jetton address: EQCB8popfslRemSz6oDGnzL-qPjhgp2IjULxjLyuCNUandhP. On-chain metadata and image are available, minting is permanently closed, and the Jetton currently has active SSL/TON liquidity on DeDust. The contract includes an admin-controlled sell-control capability which is currently disabled; sellOpen is currently true.