### PR TITLE
Add VIMIM (VIM) jetton

### DIFF
--- a/jettons/VIMIM.yaml
+++ b/jettons/VIMIM.yaml
@@ -1,0 +1,5 @@
+name: "VIMIM"
+description: "VIMIM is a community-driven token on the TON blockchain."
+image: https://raw.githubusercontent.com/younissafa5555-maker/vimim-assets/main/vimim-vim-logo.jpg
+address: EQAtogKzyv5ITSY_CrRkGmE4FAHAkFLg-s--16rgRksYEKzp
+symbol: "VIM"


### PR DESCRIPTION
Add VIMIM jetton to ton-assets for review.

Jetton address: EQAtogKzyv5ITSY_CrRkGmE4FAHAkFLg-s--16rgRksYEKzp
Symbol: VIM
Name: VIMIM
Metadata and image are publicly accessible.

Market / on-chain details:
- DeDust VIM/TON pool: EQBSOMGlCJMrG_5wC-SaldPC3KiOsP7yZEHPGJ93bNi-Y4AY
- Pool is active and recognized by TonAPI as `dedust_pool`
- Current reserves observed: ~139.99 TON and ~32.18M VIM
- DeDust swap estimation is working (1 TON -> ~227,683 VIM at the observed pool state)
- Minting is closed (`mintable: false`)
- Total supply: 120,000,000 VIM (9 decimals)

TonAPI currently recognizes the jetton metadata and pool but still reports USD rate as 0. This PR is submitted for Tonkeeper asset review/verification.