### PR TITLE
Add MGRMGA Caps collection (same project as the already-verified MGRMGA jetton)

### DIFF
--- a/collections/MGRMGA_Caps.yaml
+++ b/collections/MGRMGA_Caps.yaml
@@ -1,0 +1,10 @@
+name: MGRMGA Caps
+address: EQBTHIknd2UzW_ShBymz9gVeNJgSqSgi9UqKCNhLmOzO6PsS
+description: "Limited collection of 150 numbered caps of the MGRMGA (Make Gram Great Again) community on TON. Issued by the same team as the MGRMGA jetton, which is already verified in this repository."
+image: "https://mgrmga.org/caps-logo.png"
+social:
+  - "https://t.me/mgrmga_holders"
+  - "https://t.me/mgrmgachat"
+  - "https://x.com/MGRMGA"
+websites:
+  - "https://mgrmga.org"


### PR DESCRIPTION
Adding `collections/MGRMGA_Caps.yaml` for the MGRMGA Caps NFT collection.

**Collection:** `EQBTHIknd2UzW_ShBymz9gVeNJgSqSgi9UqKCNhLmOzO6PsS`
**Deployed:** 4 August 2026, via the Getgems deployer
**Supply:** 150 items · ~39 holders
**Market:** https://getgems.io/collection/EQBTHIknd2UzW_ShBymz9gVeNJgSqSgi9UqKCNhLmOzO6PsS

## Why this collection belongs to a known project

The MGRMGA jetton `EQDnthM6DjZLIlQ_lQlCwtj-Ez2UrYzpWUV493bcccz-Rj0c` is **already
listed in this repository** (`jettons/MGRMGA.yaml`) and TonAPI currently returns
`verification: whitelist` for it, with **10,394 holders** and an active STON.fi pool.

This NFT collection was deployed by the same team, from the project wallet
`UQAEkiQuSYPZz3QE0A2jghku2hJz7QYAP7WBHCJnA_Xx-WT4`, and points to the same
website and social accounts as the verified jetton.

## Additional request: please review the SCAM flag on the items

The items currently return `"trust": "blacklist"` (48 of the first 50 checked
today) or `"trust": "graylist"`, and Tonviewer/Tonkeeper display a **SCAM** badge
on them. The collection contract itself is `"trust": "none"` with an empty
`approved_by`, which suggests the flag was applied automatically to the items
rather than after a manual review.

We believe the trigger was a one-off gift campaign: part of the caps was sent for
free to early GRAM (GRM) holders from the project wallet. This was a targeted
gift to a small group, not a mass mailing — the whole collection is 150 items
held by ~39 wallets, and no NFT was ever sent to thousands of random addresses.

The collection metadata contains no impersonation of another collection, no
promises of profit, no "claim" or "connect wallet" links, and no external
websites other than our own. The description and images are our own artwork.

We ask you to re-check the items and remove the SCAM flag. Happy to provide any
additional proof of ownership — we can sign a message from the collection owner
wallet or publish a confirmation post in our official channel
https://t.me/mgrmga_holders.
