### PR TITLE
MGRMGA: add direct logo URL and decimals

### DIFF
--- a/jettons/MGRMGA.yaml
+++ b/jettons/MGRMGA.yaml
@@ -2,6 +2,8 @@ name: Make Gram Great Again
 description: "Fully decentralized MEME coin by the GRAM (GRM) community. Make Gram Great Again! Not affiliated with Telegram or TON Foundation."
 address: 0:e7b6133a0e364b22543f950942c2d8fe133d94ad8ce9594578f776dc71ccfe46
 symbol: MGRMGA
+image: "https://mgrmga.org/logo.png"
+decimals: 9
 websites:
   - https://mgrmga.org
 social:


### PR DESCRIPTION
Small metadata update for the already-listed MGRMGA jetton (`jettons/MGRMGA.yaml`).

**Added:**
- `image`: https://mgrmga.org/logo.png — 256x256 PNG served over plain HTTPS from the project domain.
- `decimals: 9` — matches the on-chain jetton master.

**Why the direct URL helps:** the on-chain metadata points the logo at an IPFS gateway (`gateway.pinata.cloud`). Several aggregators do not follow IPFS gateways or cache them poorly, so the token shows up without a logo on their side even though the image is reachable. A plain HTTPS URL on our own domain removes that dependency.

Nothing else in the file changed. The jetton is already verified in this repository and currently returns `verification: whitelist` from TonAPI with 10,397 holders.