### PR TITLE
Add ASAL token to jettons

### DIFF
--- a/jettons/ASAL.yaml
+++ b/jettons/ASAL.yaml
@@ -1,0 +1,9 @@
+name: Asal Token
+symbol: ASAL
+image: https://i.ibb.co/PsDXMhM8/ASAL-logo.png
+address: 0:2bbd078c0346803d7792991995dfdb549efdade9b97756e84620d05f25de7427
+description: |
+  With respect and courtesy, In this project, we strive to ensure the job security of all members while establishing a smart business model geared toward sustainable development and the distribution of profits proportionate to each shareholder's stake. Beyond the realm of computing—encompassing artificial intelligence, blockchain technology, and software development—this initiative incorporates a diverse range of other activities. These include the trading of gold, silver, and watches; educational programs; agricultural development and environmental conservation; construction projects; the tourism industry; and various charitable and philanthropic endeavors.
+website: https://tala.asalian.ir
+social:
+  - "https://t.me/ASALtoken"


### PR DESCRIPTION
This pull request adds the **ASAL token** to the `jettons/` directory. 

Please make sure you change the original .yaml fields in the `accounts/`, `collections/` or `jettons/` directories and leave the auto-generated .json files in the repository root alone. Also please make sure that you do not use ton.api links in your pull request.

**Token Information:**
- **Name:** Asal Token
- **Symbol:** ASAL
- **Address (raw):** `0:2bbd078c0346803d7792991995dfdb549efdade9b97756e84620d05f25de7427`
- **Website:** [https://tala.asalian.ir](https://tala.asalian.ir)
- **Social:** [https://t.me/ASALtoken](https://t.me/ASALtoken)

All required fields in the `ASAL.yaml` file have been completed accurately.