### PR TITLE
Add LIONFI jetton

### DIFF
--- a/jettons/LIONFI.yaml
+++ b/jettons/LIONFI.yaml
@@ -1,0 +1,3 @@
+name: LIONFI
+symbol: LIONFI
+address: EQCOzPXWWFA1VFR8jKPNij-TlA78yMZa8TP_VcMc5joZkqE9


### PR DESCRIPTION
Add LIONFI jetton to the Tonkeeper asset list.

Jetton Master address:
EQCOzPXWWFA1VFR8jKPNij-TlA78yMZa8TP_VcMc5joZkqE9
