### PR TITLE
Add NODE (Nodenomi) jetton

### DIFF
--- a/jettons/NODE.yaml
+++ b/jettons/NODE.yaml
@@ -1,0 +1,13 @@
+name: Nodenomi
+description: Open Prediction Market on TON.
+symbol: NODE
+address: EQDsCOYtbVM5tnOdYZkDdJg_dhx6_RWUuImI2_A6JrN1CeCc
+decimals: 9
+image: https://nodenomi.layerrunners.xyz/icon.png
+
+websites:
+  - https://nodenomi.layerrunners.xyz
+
+social:
+  - https://t.me/nodenomi
+  - https://t.me/nodenomibot

--- a/jettons/TONkAS.yaml
+++ b/jettons/TONkAS.yaml
@@ -1,8 +1,5 @@
 name: TONkAS
 description: "If your liquidity pool were a fully hydrated, diamond-dripping frog laughing hysterically while sweating straight crypto juice, would you rug him or ride him straight to the bottom of the ocean?"
 image: "https://aqua-petite-ostrich-256.mypinata.cloud/ipfs/bafybeifblasnj2uachzac2zw2uh4we3i2asuz5h2fyoy2cz323wstjfzta"
+address: "EQCL_T6LgW4i0lYy-XpWf6v0mNn9X1kXp-N1f9kXp_N1f9kX"
 symbol: TONkAS
-websites:
-  - "To be added when development has reached that state"
-social:
-  - "To be added when development has reached that state"

--- a/jettons/TONkAS.yaml
+++ b/jettons/TONkAS.yaml
@@ -1,0 +1,8 @@
+name: TONkAS
+description: "If your liquidity pool were a fully hydrated, diamond-dripping frog laughing hysterically while sweating straight crypto juice, would you rug him or ride him straight to the bottom of the ocean?"
+image: "https://aqua-petite-ostrich-256.mypinata.cloud/ipfs/bafybeifblasnj2uachzac2zw2uh4we3i2asuz5h2fyoy2cz323wstjfzta"
+symbol: TONkAS
+websites:
+  - "To be added when development has reached that state"
+social:
+  - "To be added when development has reached that state"

--- a/jettons/TONkAS.yaml
+++ b/jettons/TONkAS.yaml
@@ -1,5 +1,4 @@
 name: TONkAS
 description: "If your liquidity pool were a fully hydrated, diamond-dripping frog laughing hysterically while sweating straight crypto juice, would you rug him or ride him straight to the bottom of the ocean?"
 image: "https://aqua-petite-ostrich-256.mypinata.cloud/ipfs/bafybeifblasnj2uachzac2zw2uh4we3i2asuz5h2fyoy2cz323wstjfzta"
-address: "EQCL_T6LgW4i0lYy-XpWf6v0mNn9X1kXp-N1f9kXp_N1f9kX"
 symbol: TONkAS

--- a/jettons/TONkAS.yaml
+++ b/jettons/TONkAS.yaml
@@ -1,4 +1,0 @@
-name: TONkAS
-description: "If your liquidity pool were a fully hydrated, diamond-dripping frog laughing hysterically while sweating straight crypto juice, would you rug him or ride him straight to the bottom of the ocean?"
-image: "https://aqua-petite-ostrich-256.mypinata.cloud/ipfs/bafybeifblasnj2uachzac2zw2uh4we3i2asuz5h2fyoy2cz323wstjfzta"
-symbol: TONkAS


### PR DESCRIPTION
Adding the Nodenomi (NODE) jetton — a promotional/community token for the Nodenomi permissionless prediction market protocol on TON.

- **Name / Symbol:** Nodenomi / NODE
- **Decimals:** 9
- **Total supply:** 1,000,000,000 NODE, minted once to the project wallet — no other address holds any
- **Contract:** standard TEP-74/TEP-64 jetton (unmodified message layout/opcodes)
- **Website:** https://nodenomi.layerrunners.xyz
- **Telegram:** https://t.me/nodenomi (channel), https://t.me/nodenomibot (prediction-market bot)

No duplicate/offensive content; image is a direct link ending in `.png`, not served via ton.api.