### PR TITLE
Add NODE (Nodenomi) jetton

### DIFF
--- a/jettons/NODE.yaml
+++ b/jettons/NODE.yaml
@@ -1,0 +1,13 @@
+name: Nodenomi
+description: Open Prediction Market on TON.
+symbol: NODE
+address: EQDsCOYtbVM5tnOdYZkDdJg_dhx6_RWUuImI2_A6JrN1CeCc
+decimals: 9
+image: https://nodenomi.layerrunners.xyz/icon.png
+
+websites:
+  - https://nodenomi.layerrunners.xyz
+
+social:
+  - https://t.me/nodenomi
+  - https://t.me/nodenomibot


### PR DESCRIPTION
Adding the Nodenomi (NODE) jetton — a promotional/community token for the Nodenomi permissionless prediction market protocol on TON.

- **Name / Symbol:** Nodenomi / NODE
- **Decimals:** 9
- **Total supply:** 1,000,000,000 NODE, minted once to the project wallet — no other address holds any
- **Contract:** standard TEP-74/TEP-64 jetton (unmodified message layout/opcodes)
- **Website:** https://nodenomi.layerrunners.xyz
- **Telegram:** https://t.me/nodenomi (channel), https://t.me/nodenomibot (prediction-market bot)

No duplicate/offensive content; image is a direct link ending in `.png`, not served via ton.api.