### PR TITLE
Add Chuvash Lang Club NFT passport collection

### DIFF
--- a/collections/ChuvashLangClub.yaml
+++ b/collections/ChuvashLangClub.yaml
@@ -1,6 +1,6 @@
 name: "Чӑваш Чӗлхи Клубӗ"
 description: "NFT-паспорт гражданина языкового клуба «Чӑваш Чӗлхи Клубӗ» (BLC DAO). Гражданство civic — primary; NFT — бейдж / wallet-path для других ДАО."
-address: EQCfmXE_mATfhwWbslp9f2DGlXR0qTZ4VnIFCQ2KmD13IEi-
+address: EQDHiLWt5Yz60g47tWpDlJs8BZm1l4g0rYYJ3ZFFEp9WzU-B
 image: "https://dao.blc.cab/nft/chuvash-lang-passport.png"
 websites:
   - "https://dao.blc.cab"

--- a/collections/ChuvashLangClub.yaml
+++ b/collections/ChuvashLangClub.yaml
@@ -1,0 +1,9 @@
+name: "Чӑваш Чӗлхи Клубӗ"
+description: "NFT-паспорт гражданина языкового клуба «Чӑваш Чӗлхи Клубӗ» (BLC DAO). Гражданство civic — primary; NFT — бейдж / wallet-path для других ДАО."
+address: EQCfmXE_mATfhwWbslp9f2DGlXR0qTZ4VnIFCQ2KmD13IEi-
+image: "https://dao.blc.cab/nft/chuvash-lang-passport.png"
+websites:
+  - "https://dao.blc.cab"
+  - "https://t.me/dao_gram_bot?startapp=Chuvash_Lang"
+social:
+  - "https://t.me/dao_gram_bot"


### PR DESCRIPTION
## Summary
- Add verified entry for BLC DAO language club «Чӑваш Чӗлхи Клубӗ» NFT passport collection
- Collection: `EQCfmXE_mATfhwWbslp9f2DGlXR0qTZ4VnIFCQ2KmD13IEi-`
- Owner: club DAO `EQC2NMctYN_fZhtueJw5lpt1lkXZQhIbe91W6RfjmsN5wqIE`
- Image: direct HTTPS PNG on `https://dao.blc.cab/nft/chuvash-lang-passport.png` (not tonapi)

## Context
Soulbound civic passport badge for language-club citizens (wallet-path into main civic DAOs). On-chain TEP-64 currently points at Wikimedia (blocked by wallet scrapers); this assets entry supplies a reachable image + collection name for Tonkeeper.

## Checklist
- [x] Only `collections/*.yaml` changed
- [x] Image URL ends with `.png` and is a direct file link
- [x] No duplicate address (new collection)
