### PR TITLE
Add BAZEFi (BZF) jetton

### DIFF
--- a/jettons/bazefi-bzf.yaml
+++ b/jettons/bazefi-bzf.yaml
@@ -1,0 +1,5 @@
+name: BAZEFi
+description: BAZEFi (BZF) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/bazefi-assets/main/bazefi-bzf-logo.jpg
+address: EQD61HdOvlRkWHQq6ZiDMEPjF1U43osQjk5CsO_8mOro1n6g
+symbol: BZF


### PR DESCRIPTION
Please review BAZEFi (BZF) for the Tonkeeper asset registry.

Jetton address: EQD61HdOvlRkWHQq6ZiDMEPjF1U43osQjk5CsO_8mOro1n6g

On-chain metadata and image are available, minting is permanently closed, and the Jetton currently has active BZF/TON liquidity on DeDust.

The contract includes an admin-controlled sell-control capability. At submission it was disabled with sellOpen=true. The intended use is a transparent, time-limited 35-hour sell lock with paused=false and automatic reopening at lockedUntil. While that timed lock is active, ordinary BZF transfers into the DeDust Jetton vault are rejected; the liquidity-manager DeDust liquidity-deposit path remains exempt.