### PR TITLE
Add TEMLYR Creator Cups NFT collection

### DIFF
--- a/TEMLYR-Creator-Cups.yaml
+++ b/TEMLYR-Creator-Cups.yaml
@@ -1,0 +1,10 @@
+name: TEMLYR Creator Cups
+address: 0:ee160f7bf009d8e6d07499b190db11d4a7801ea419c98497453e33aa54d7afb7
+description: Unique 1/1 championship trophy NFTs awarded to winners of the weekly TEMLYR Creator Cup tournament on TON Mainnet.
+image: https://temlyr.com/assets/creator-cup.png
+social:
+  - https://t.me/temlyr
+  - https://t.me/temlyr_chat
+  - https://t.me/temlyr_game_bot
+websites:
+  - https://temlyr.com/games/temlyr/creator-cup/


### PR DESCRIPTION
Adds the official TEMLYR Creator Cups NFT collection to ton-assets.

TEMLYR Creator Cups are unique 1/1 championship trophies awarded to winners of the weekly TEMLYR Creator Cup tournament on TON Mainnet.

Official project:
https://temlyr.com

Creator Cup page:
https://temlyr.com/games/temlyr/creator-cup/

Collection:
EQDuFg978AnY5tB0mbGQ2xHUp4AepBnJhJdFPjOqVNevt9qc

The first Creator Cup NFT has already been minted and awarded to a tournament winner.

Thank you for reviewing the collection.