### PR TITLE
Add FENIXCHAIN (FNX) jetton

### DIFF
--- a/jettons/FNX.yaml
+++ b/jettons/FNX.yaml
@@ -1,0 +1,5 @@
+name: FENIXCHAIN
+description: FENIXCHAIN (FNX) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/fenixchain-assets/main/fenixchain-fnx-logo.jpg
+address: EQAG2rgeZvEUppDC3QOvJyP88zL1bW6NoIcJVxbwdanVxu4N
+symbol: FNX


### PR DESCRIPTION
Adds FENIXCHAIN (FNX) to the Tonkeeper jetton registry.

Jetton master: `EQAG2rgeZvEUppDC3QOvJyP88zL1bW6NoIcJVxbwdanVxu4N`
Symbol: `FNX`
Decimals: `9`
Total supply: `120,000,000 FNX`
Minting is permanently closed.

Active FNX/TON liquidity is deployed on DeDust with approximately `150 TON + 7,999,999.999999500 FNX` in the pool.

Transparency note: the jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended use is a transparent, time-limited 72-hour lock with `paused=false` and automatic reopening after the configured timestamp. While such a timed lock is active, ordinary FNX transfers into the DeDust jetton vault are rejected, while the designated liquidity-manager deposit flow remains exempt.

Metadata image: `https://raw.githubusercontent.com/younissafa5555-maker/fenixchain-assets/main/fenixchain-fnx-logo.jpg`