### PR TITLE
Add Freedom (FRDM) jetton

### DIFF
--- a/jettons/FRDM.yaml
+++ b/jettons/FRDM.yaml
@@ -1,0 +1,6 @@
+name: Freedom
+symbol: FRDM
+decimals: 9
+description: "The currency of the Order of Freedom — uniting people to defend freedom and privacy, expand knowledge, and build a free future. Everything begins with freedom."
+image: "https://raw.githubusercontent.com/VechnoeTsukuyomi/frdm-assets/main/frdm.png"
+address: EQCuo36wxohB45p5UFmsPKLBCoT0BR_REkianmiuzF3Rlx-N

--- a/jettons/FRDM.yaml
+++ b/jettons/FRDM.yaml
@@ -4,3 +4,7 @@ decimals: 9
 description: "The currency of the Order of Freedom — uniting people to defend freedom and privacy, expand knowledge, and build a free future. Everything begins with freedom."
 image: "https://raw.githubusercontent.com/VechnoeTsukuyomi/frdm-assets/main/frdm.png"
 address: EQCuo36wxohB45p5UFmsPKLBCoT0BR_REkianmiuzF3Rlx-N
+websites:
+  - "https://t.me/OrderOfFreedomBot"
+social:
+  - "https://t.me/OrderOfFreedom"


### PR DESCRIPTION
Adding the Freedom (FRDM) jetton to the registry.

| Field | Value |
| --- | --- |
| Name | Freedom |
| Symbol | FRDM |
| Decimals | 9 |
| Jetton Master | `EQCuo36wxohB45p5UFmsPKLBCoT0BR_REkianmiuzF3Rlx-N` |

FRDM is the token of Order of Freedom, a Telegram Mini App community project.

- App: https://t.me/OrderOfFreedomBot
- Channel: https://t.me/OrderOfFreedom

The logo is a direct HTTPS link ending in `.png`, hosted in a public repository — no `ton.api` links are used:
https://raw.githubusercontent.com/VechnoeTsukuyomi/frdm-assets/main/frdm.png

This PR touches only `jettons/FRDM.yaml`. The auto-generated `.json` files in the repository root are left untouched.