### PR TITLE
Add Pyonya PFPs collection

### DIFF
--- a/collections/PyonyaPFPs.yaml
+++ b/collections/PyonyaPFPs.yaml
@@ -1,0 +1,10 @@
+name: "Pyonya PFPs"
+description: Pyonya PFPs on TON. Durov's dog. 1,669 supply. stay fluffy. woof.
+address: EQDzVmDgiL1rtuRy_03LyEvCjhnCq122BiN8C57Z6PFZhKu4
+websites:
+- "https://pyonya.com/"
+social:
+- "https://x.com/PYONYATON"
+- "https://t.me/PYONYATON"
+- "https://t.me/PYONYA_TON"
+image: "https://ddejfvww7sqtk.cloudfront.net/user-media/16-05-2026/11110377/1861396.gif"


### PR DESCRIPTION
Adding the Pyonya PFPs NFT collection (1,669 items, minted on GetGems, live since May 2026).

Collection: EQDzVmDgiL1rtuRy_03LyEvCjhnCq122BiN8C57Z6PFZhKu4
Marketplace: https://getgems.io/collection/EQDzVmDgiL1rtuRy_03LyEvCjhnCq122BiN8C57Z6PFZhKu4
Website: https://pyonya.com/

The PYONYA jetton by the same project is already whitelisted.