### PR TITLE
Add VEXON (VEX) Jetton

### DIFF
--- a/jettons/VEXON.yaml
+++ b/jettons/VEXON.yaml
@@ -3,6 +3,6 @@ symbol: VEX
 address: EQAO_g2ulhgbclc72IzXnNxC4agHrbd18MazA-TCLMjH8R2q
 decimals: 9
 websites:
-  - "https://vexon-red.vercel.app"
+  - "https://vexon.space"
 social:
   - "https://t.me/vexon_miningbot"

--- a/jettons/VEXON.yaml
+++ b/jettons/VEXON.yaml
@@ -1,0 +1,8 @@
+name: VEXON
+symbol: VEX
+address: EQAO_g2ulhgbclc72IzXnNxC4agHrbd18MazA-TCLMjH8R2q
+decimals: 9
+websites:
+  - "https://vexon-red.vercel.app"
+social:
+  - "https://t.me/vexon_miningbot"

--- a/jettons/VEXON.yaml
+++ b/jettons/VEXON.yaml
@@ -5,4 +5,4 @@ decimals: 9
 websites:
   - "https://vexon.space"
 social:
-  - "https://t.me/vexon_miningbot"
+  - "https://t.me/vexon_community"


### PR DESCRIPTION
Add VEXON (VEX), the utility Jetton of the VEXON Telegram mining ecosystem.

```yaml
address: EQAO_g2ulhgbclc72IzXnNxC4agHrbd18MazA-TCLMjH8R2q
symbol: VEX
websites:
  - "https://vexon-red.vercel.app"
social:
  - "https://t.me/vexon_miningbot"