### PR TITLE
Add CAP (CAPITAL) jetton

### DIFF
--- a/jettons/CAP.yaml
+++ b/jettons/CAP.yaml
@@ -1,0 +1,7 @@
+name: CAPITAL
+description: "Token for launching other tokens, backed by a basket of collateral assets (BTC, ETH, USDT, GRAM, POK) with algorithmic market making. #ProofOfCapital"
+address: EQDIUPiVCgPll5gSTjlkz7HMAbUv0QTzCLvlHO177tK6nfeW
+symbol: CAP
+image: "https://cap.proofofkarl.com/logo.jpg"
+websites:
+  - "https://cap.proofofkarl.com"


### PR DESCRIPTION
Adding CAPITAL (CAP) — token for launching other tokens on TON, backed by a basket of collateral assets (BTC, ETH, USDT, GRAM, POK) with algorithmic market making.

Website: https://cap.proofofkarl.com
Jetton master: EQDIUPiVCgPll5gSTjlkz7HMAbUv0QTzCLvlHO177tK6nfeW
On-chain metadata matches this listing.