### PR TITLE
Add GramLeek (LEEK)

### DIFF
--- a/jettons/LEEK.yaml
+++ b/jettons/LEEK.yaml
@@ -1,0 +1,10 @@
+name: "GramLeek"
+symbol: "LEEK"
+address: "EQAmoQqDz6woBJ1dvwFl14PHdD6CE3eVMd58INFRKp3n9Ycw"
+description: "Not a vegetable."
+image: "https://raw.githubusercontent.com/GramLeek/Assets/refs/heads/main/Logo.png"
+social:
+  - "https://t.me/GramLeek"
+  - "https://x.com/GramLeek"
+websites:
+  - "https://gramleek.xyz"


### PR DESCRIPTION
Add GramLeek (LEEK) jetton to the Tonkeeper asset list.

Jetton address:
EQAmoQqDz6woBJ1dvwFl14PHdD6CE3eVMd58INFRKp3n9Ycw

Logo and project links are included in LEEK.yaml.