### PR TITLE
.TG Domains — whitelist & remove false-positive scam mark

### DIFF
--- a/collections/tgdomains.yaml
+++ b/collections/tgdomains.yaml
@@ -1,0 +1,9 @@
+name: ".TG Domains"
+description: "Verified .tg domain ownership certificates issued by GDomains. Each NFT represents a unique domain name and grants its holder full control over the buy, rental and resale of the name on the GDomains and GetGems platforms."
+image: "https://raw.githubusercontent.com/giftcollection-ui/logo/main/tgdomains.png"
+address: "EQDDXd9DwycN-5wHGfH0Nxw83gUBwsB5FWylIhKeJt9jRMFA"
+websites:
+  - "https://reg.tg/"
+social:
+  - "https://t.me/regtg"
+  - "https://t.me/tgdomains_bot"


### PR DESCRIPTION
Collection: .TG Domains
Address: EQDDXd9DwycN-5wHGfH0Nxw83gUBwsB5FWylIhKeJt9jRMFA
Website: https://reg.tg and https://t.me/tgdomains_bot
Telegram: https://t.me/regtg or https://t.me/buytgrent
Getgems: https://getgems.io/collection/EQDDXd9DwycN-5wHGfH0Nxw83gUBwsB5FWylIhKeJt9jRMFA

I am the owner of the collection contract. Proof: announcement linking
this PR is posted in our official channel: <https://t.me/regtg/22)>

IMPORTANT — false-positive scam mark. Items of this collection are
currently marked as scam (trust: blacklist) by mistake:

- voice.tg  0:003b9289388329fec9173a2d5401e9e138114d826f544dae1b1b1162146d92ef
- bets.tg   0:fa8707dc7d5628556a471aa79f085ff92b0601130df81bcec6b976b94baebf0b
- boss.tg   0:43e98502a31037fbe7b5e4ef1e89fcb3d84cc1d070c3575336ce3412a4853d7c
- prem.tg   0:e9525cbf872ab9cbb27f5903d8bfa15a6f4b2f1161ff10ec2fafb8fac8043559
- gta6.tg   0:6df81cf7e3133625f0bd26431d2b6c9fd6b8034fd9560df0d9e438871b0e7ec2

These NFTs are .tg domain ownership certificates. Each one is minted
only after a real user purchases the domain in our app (@tgdomains_bot) — they
are never airdropped unsolicited. This looks like the same false
positive as in #5996. Please review and remove the scam mark from the
collection items (whitelisting would also be appreciated, but removing
the wrongful blacklist is the priority).