### PR TITLE
Add Salovich 2.0 NFT collection

### DIFF
--- a/collections/Salovich-2.0.yaml
+++ b/collections/Salovich-2.0.yaml
@@ -1,0 +1,4 @@
+name: "Salovich 2.0"
+description: "Personal NFT collection of 70 original Salovich 2.0 stickers on TON."
+image: "https://gateway.pinata.cloud/ipfs/bafybeie7xw5wmzmno7okm5t6vfvq6pbj6rad2moov7t5bam3df7a24lpym/001.webp"
+address: "UQCLnD_WuaogqJP6klfyPJXhiIXDhRbOZlqaIchPTQd7Z_NH"


### PR DESCRIPTION
Adds the Salovich 2.0 NFT collection for verification.

- Collection address: UQCLnD_WuaogqJP6klfyPJXhiIXDhRbOZlqaIchPTQd7Z_NH
- Supply: 70 NFT items
- Image: direct IPFS gateway link ending in .webp

No generated JSON files are changed.