### PR TITLE
Add Grandmaster Lab — The Challenger collection

### DIFF
--- a/collections/GrandmasterLab.yaml
+++ b/collections/GrandmasterLab.yaml
@@ -1,0 +1,8 @@
+name: "Grandmaster Lab — The Challenger"
+description: "An independent digital collection of 6000 items dedicated to Javokhir Sindarov, winner of the 2026 Candidates Tournament. Grandmaster Lab is not affiliated with Telegram and this is not an official Telegram Gift Collection."
+image: "https://app.grandmasterlab.com/logo.png"
+address: "EQA_anguWd5NQDdtB0sYSUtBGjSEy3fjRcX-IYtQCfQ-EuAz"
+websites:
+  - "https://app.grandmasterlab.com"
+social:
+  - "https://t.me/grandmasterlab_bot"


### PR DESCRIPTION
Adding the collection metadata for **Grandmaster Lab — The Challenger**.

- **Collection:** `EQA_anguWd5NQDdtB0sYSUtBGjSEy3fjRcX-IYtQCfQ-EuAz`
- **Website:** https://app.grandmasterlab.com
- **Telegram:** https://t.me/grandmasterlab_bot
- **Image:** https://app.grandmasterlab.com/logo.png (direct `.png` link, no redirects)

An independent collection of 6000 digital collectibles dedicated to Javokhir Sindarov, winner of the 2026 Candidates Tournament. Sold through a Telegram Mini App for Telegram Stars and on the web for GRAM; items are minted to the buyer's own wallet on request.

The collection is not affiliated with Telegram and is not a Telegram Gift Collection — this is stated in the collection metadata and in the app itself.

Metadata is served over HTTPS from the project domain:
- collection: `https://app.grandmasterlab.com/meta/collection.json`
- items: `https://app.grandmasterlab.com/meta/{index}.json`

Royalty is 5%. Only the single `.yaml` file was added; no generated files were touched.