### PR TITLE
Add CYBERPULSE (CBP) jetton

### DIFF
--- a/jettons/CBP.yaml
+++ b/jettons/CBP.yaml
@@ -1,0 +1,5 @@
+name: CYBERPULSE
+description: CYBERPULSE (CBP) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/cyberpulse-assets/main/cyberpulse-cbp-logo.jpg
+address: EQDQ6ZKI_c-Zzb2e4Q3D0C8atchCSYtWa80DcFdEbakUQlHq
+symbol: CBP


### PR DESCRIPTION
Adds CYBERPULSE (CBP) to the Tonkeeper jetton registry.

Jetton master: `EQDQ6ZKI_c-Zzb2e4Q3D0C8atchCSYtWa80DcFdEbakUQlHq`
Symbol: `CBP`
Decimals: `9`
Total supply: `120,000,000 CBP`
Minting is permanently closed.

Active CBP/TON liquidity is deployed on DeDust with `200 TON + 12,000,000 CBP` in the pool.

Transparency note: the jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended use is a transparent, time-limited 72-hour lock with `paused=false` and automatic reopening after the configured timestamp. While such a timed lock is active, ordinary CBP transfers into the DeDust jetton vault are rejected, while the designated liquidity-manager deposit flow remains exempt.

Metadata image: `https://raw.githubusercontent.com/younissafa5555-maker/cyberpulse-assets/main/cyberpulse-cbp-logo.jpg`