### PR TITLE
Add HydraNFT — Crownville Legendary Artifacts

### DIFF
--- a/collections/HydraNFT.yaml
+++ b/collections/HydraNFT.yaml
@@ -1,0 +1,8 @@
+name: "HydraNFT — Crownville Legendary Artifacts"
+description: "On-chain legendary artifacts of the Crownville game. Each HydraNFT runs your in-game legendary at full 100% power and is forged from 10 legendary artifacts plus a Basilisk. 1200 pieces across 12 types, from Common to Very Rare."
+image: "https://nft.crownville.online/api/nft/hydra/img/cover-royal.png"
+address: EQBANB_ReZ0yim_7Otwio7Ut6s-3tP9GBG6SadLpC9j1QHGZ
+websites:
+- "https://crownville.online/"
+social:
+- "https://t.me/CrownvilleSurvivorsBot"

--- a/collections/MemberRewards Genesis.yaml
+++ b/collections/MemberRewards Genesis.yaml
@@ -1,0 +1,8 @@
+name: "MemberRewards Genesis"
+address: "EQDSoIlm50Hrl3m18FtBQRMESf4Gt3DT5aD4SYf7pwSUjZwU"
+description: "Founding membership collection of the MemberRewards influencer-marketing platform on TON."
+image: "https://nft.memberrewards.pro/assets/nft-cover.png"
+websites:
+  - "https://memberrewards.pro/"
+social:
+  - "https://t.me/MemberRewardsBot"


### PR DESCRIPTION
Adds the HydraNFT — Crownville Legendary Artifacts collection (EQBANB_ReZ0yim_7Otwio7Ut6s-3tP9GBG6SadLpC9j1QHGZ). It is a legitimate in-game NFT collection for the Crownville game (1200 items, 12 types). Freshly minted items are currently being flagged; requesting whitelist so genuine holders can see their NFTs. Website: https://crownville.online