### PR TITLE
Add TERRANOVA (TRN) jetton

### DIFF
--- a/jettons/TRN.yaml
+++ b/jettons/TRN.yaml
@@ -1,0 +1,5 @@
+name: TERRANOVA
+description: TERRANOVA (TRN) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/terranova-assets/main/terranova-trn-logo.jpg
+address: EQCEMdWq7X_zwYRmWNYPzk8YLVj5DttRuCe3ObS304LUKRNB
+symbol: TRN


### PR DESCRIPTION
Adds TERRANOVA (TRN) to the Tonkeeper jetton registry.

Jetton master: `EQCEMdWq7X_zwYRmWNYPzk8YLVj5DttRuCe3ObS304LUKRNB`
Symbol: `TRN`
Decimals: `9`
Total supply: `120,000,000 TRN`
Minting is permanently closed.

Active TRN/TON liquidity is deployed on DeDust with `200 TON + 12,000,000 TRN` in the pool.

Transparency note: the jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended use is a transparent, time-limited 72-hour lock with `paused=false` and automatic reopening after the configured timestamp. While such a timed lock is active, ordinary TRN transfers into the DeDust jetton vault are rejected, while the designated liquidity-manager deposit flow remains exempt.

Metadata image: `https://raw.githubusercontent.com/younissafa5555-maker/terranova-assets/main/terranova-trn-logo.jpg`