### PR TITLE
Add INFINITYLAB IFL jetton

### DIFF
--- a/jettons/IFL.yaml
+++ b/jettons/IFL.yaml
@@ -1,0 +1,5 @@
+name: INFINITYLAB
+description: INFINITYLAB (IFL) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/infinitylab-assets/main/infinitylab-ifl-logo.jpg
+address: EQCzkGLR7rN78aqtJrTOh6EBDTepmAL6mkwnL_XRFXhl48Fx
+symbol: IFL


### PR DESCRIPTION
Adds INFINITYLAB (IFL) to the Tonkeeper jetton registry.

Jetton master: `EQCzkGLR7rN78aqtJrTOh6EBDTepmAL6mkwnL_XRFXhl48Fx`
Total supply: 120,000,000 IFL
Decimals: 9
Minting: permanently closed
Initial DeDust liquidity: 400 TON + 12,000,000 IFL
Initial ratio: 1 TON = 30,000 IFL

Transparency note: the jetton wallet contract includes an admin-controlled sell-control feature. It is currently disabled. The intended configuration is a transparent, time-limited 150-hour lock with `paused=false` and automatic reopening after `lockedUntil`. While active, ordinary IFL transfers into the DeDust jetton vault are rejected; the designated liquidity-manager deposit path is exempt so liquidity operations can complete. This capability is disclosed here intentionally and is not intended as a permanent or hidden restriction.