### PR TITLE
Add RawStars custodian configuration

### DIFF
--- a/accounts/custodians.yaml
+++ b/accounts/custodians.yaml
@@ -433,3 +433,7 @@
   name: "Changelly 2"
 - address: "UQAU3ksCZHlBd5EIt7mb6FWWJgzN6BM1EAAFXXRN2KugTJYl"
   name: "CoinEx"
+- address: "UQByHzgY7-50L2iy_dI98MuaNXbBAiFlhHO89cCpX--Stars"
+  name: "RawStars"
+  require_memo: true
+  image: "https://rawstars.tg/logo.svg"


### PR DESCRIPTION
Add RawStars custodial deposit address.
Memo is required to correctly identify and credit user deposits.
Website: https://rawstars.tg