### PR TITLE
Add official Apes Club NFT collections

### DIFF
--- a/collections/ApesClubAwakened.yaml
+++ b/collections/ApesClubAwakened.yaml
@@ -1,0 +1,10 @@
+name: "Awakened Ape"
+description: "Awakened Ape — an official Apes Club on-chain collectible on TON Mainnet."
+address: "EQBqhEriXcIh2iS0oACVu8OyC3RFGlJuEdBBgdDG72VMEZSO"
+websites:
+  - "https://telegramgift.com"
+  - "https://t.me/apes_Club_Bot/apes_club?startapp"
+social:
+  - "https://t.me/ApesClubio"
+  - "https://x.com/apes_clubio"
+image: "https://nft-assets.telegramgift.com/ton-nft/mainnet/920fc23e-4274-4e5e-bc87-73d4a6548d25/artwork/awakened-ape/image.jpg"

--- a/collections/ApesClubKingDrip.yaml
+++ b/collections/ApesClubKingDrip.yaml
@@ -1,0 +1,10 @@
+name: "King Drip Ape"
+description: "King Drip Ape — an official Apes Club on-chain collectible on TON Mainnet."
+address: "EQBRwZDCzSUGlkXtb3WRBc-OfgK-Y-CJ9qR0mF4xMqdd4G-5"
+websites:
+  - "https://telegramgift.com"
+  - "https://t.me/apes_Club_Bot/apes_club?startapp"
+social:
+  - "https://t.me/ApesClubio"
+  - "https://x.com/apes_clubio"
+image: "https://nft-assets.telegramgift.com/ton-nft/mainnet/920fc23e-4274-4e5e-bc87-73d4a6548d25/artwork/king-drip-ape/image.jpg"

--- a/collections/ApesClubMadSmile.yaml
+++ b/collections/ApesClubMadSmile.yaml
@@ -1,0 +1,10 @@
+name: "Mad Smile Ape"
+description: "Mad Smile Ape — an official Apes Club on-chain collectible on TON Mainnet."
+address: "EQAdJUYrVSN0QBfghKf6LGGHR7Z-rIHSGGtqRqgRx-a_wHN7"
+websites:
+  - "https://telegramgift.com"
+  - "https://t.me/apes_Club_Bot/apes_club?startapp"
+social:
+  - "https://t.me/ApesClubio"
+  - "https://x.com/apes_clubio"
+image: "https://nft-assets.telegramgift.com/ton-nft/mainnet/920fc23e-4274-4e5e-bc87-73d4a6548d25/artwork/mad-smile-ape/image.jpg"

--- a/collections/ApesClubSignup.yaml
+++ b/collections/ApesClubSignup.yaml
@@ -1,0 +1,10 @@
+name: "Signup Ape"
+description: "Signup Ape — the official free Apes Club on-chain reward assigned when a user joins the bot."
+address: "EQDhxwNo2KPzFkU3u5gy65UaG2dD1A2UnCoiMlbv1_8zv2xQ"
+websites:
+  - "https://telegramgift.com"
+  - "https://t.me/apes_Club_Bot/apes_club?startapp"
+social:
+  - "https://t.me/ApesClubio"
+  - "https://x.com/apes_clubio"
+image: "https://nft-assets.telegramgift.com/ton-nft/mainnet/920fc23e-4274-4e5e-bc87-73d4a6548d25/artwork/signup-ape/nft-1.jpg"


### PR DESCRIPTION
Registers the four official Apes Club NFT collections deployed on TON Mainnet.

All four collections:

- are indexed by TonAPI as active `nft_collection` contracts;
- return complete, non-broken on-chain metadata;
- share the same official project owner;
- link to the official Apes Club website, Mini App, Telegram, and X accounts.

Collections:

- Mad Smile Ape — `EQAdJUYrVSN0QBfghKf6LGGHR7Z-rIHSGGtqRqgRx-a_wHN7`
- King Drip Ape — `EQBRwZDCzSUGlkXtb3WRBc-OfgK-Y-CJ9qR0mF4xMqdd4G-5`
- Awakened Ape — `EQBqhEriXcIh2iS0oACVu8OyC3RFGlJuEdBBgdDG72VMEZSO`
- Signup Ape — `EQDhxwNo2KPzFkU3u5gy65UaG2dD1A2UnCoiMlbv1_8zv2xQ`

Official links:

- Website: https://telegramgift.com
- Mini App: https://t.me/apes_Club_Bot/apes_club?startapp
- Telegram: https://t.me/ApesClubio
- X: https://x.com/apes_clubio
- Previously merged official APE jetton registration: https://github.com/tonkeeper/ton-assets/pull/6005

Only four source YAML files under `collections/` are changed. Generated JSON and README files are intentionally untouched.