### PR TITLE
jettons: add $GSC (Gram super cycle)

### DIFF
--- a/jettons/$GSC.yaml
+++ b/jettons/$GSC.yaml
@@ -1,0 +1,8 @@
+name: "Gram super cycle"
+symbol: "GSC"
+address: "EQAmaMdwCmpZNJSRfvbNZDu1HkjFbw2VtvvI1FDKvLJMgyXE"
+description: "The coin of the #GRAMSUPERCYCLE. Powers Saturn, the capital house on TON — membership, launch access and commit capacity are all held in $GSC."
+image: "https://saturn.tg/tokens/gsc.png"
+social:
+  - "https://saturn.tg"
+  - "https://t.me/hollowjournal"


### PR DESCRIPTION
Adds a curated entry for GSC (currently only in jettons/imported_from_dex.yaml).

- Jetton: EQAmaMdwCmpZNJSRfvbNZDu1HkjFbw2VtvvI1FDKvLJMgyXE (whitelist-verified, admin renounced — on-chain content is immutable, which is why the curated image matters)
- Image: direct .png, self-hosted on the project's own domain (https://saturn.tg/tokens/gsc.png)
- Description: the token powers Saturn (saturn.tg), the capital house on TON, where membership/launch access/commit capacity are held in $GSC