### PR TITLE
Add THUNDERSWAP TSP jetton

### DIFF
--- a/jettons/TSP.yaml
+++ b/jettons/TSP.yaml
@@ -1,0 +1,5 @@
+name: THUNDERSWAP
+description: THUNDERSWAP (TSP) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/thunderswap-assets/main/thunderswap-tsp-logo.jpg
+address: EQCOI1Yl44gxXowjWn5v_MzHtfRpqoEO-HD8hMNAV_XhEm2s
+symbol: TSP


### PR DESCRIPTION
Adds THUNDERSWAP (TSP) to the Tonkeeper jetton registry.

Jetton master: `EQCOI1Yl44gxXowjWn5v_MzHtfRpqoEO-HD8hMNAV_XhEm2s`
Total supply: 120,000,000 TSP
Decimals: 9
Minting: permanently closed
Initial DeDust liquidity: 200 TON + 12,000,000 TSP
Initial ratio: 1 TON = 60,000 TSP

Additional review request: TonAPI currently returns `verification: blacklist` for this jetton, so Tonkeeper may hide it from the normal wallet token list. We noticed that the ticker TSP is already used by the whitelisted TRANSPARENT jetton (`0:2be8556a41f92d2ac8e10e1b64fac4278d7b0e8de8697fa5abfd33e8cc66d6e0`). THUNDERSWAP is a completely separate jetton with a different master address. Please review the blacklist status and remove the scam/blacklist mark if this ticker collision caused an automatic false positive.

Transparency note: the jetton wallet contract includes an admin-controlled sell-control feature. It is currently configured as a transparent, time-limited 150-hour lock with `paused=false` and automatic reopening after `lockedUntil`. While active, ordinary TSP transfers into the DeDust jetton vault are rejected; the designated liquidity-manager deposit path is exempt. This capability is disclosed intentionally and is not intended as a permanent or hidden restriction.