### PR TITLE
Add SHADOWFI SDF jetton

### DIFF
--- a/jettons/SDF.yaml
+++ b/jettons/SDF.yaml
@@ -1,0 +1,5 @@
+name: SHADOWFI
+description: SHADOWFI (SDF) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/shadowfi-assets/main/shadowfi-sdf-logo.jpg
+address: EQA1uH8V9ygze595n92ky7wTey9V54wP6hqhD-vJbZfUfkk6
+symbol: SDF


### PR DESCRIPTION
Adds SHADOWFI (SDF) to the Tonkeeper jetton registry.

Jetton master: `EQA1uH8V9ygze595n92ky7wTey9V54wP6hqhD-vJbZfUfkk6`
Total supply: 120,000,000 SDF
Decimals: 9
Minting: permanently closed
Initial DeDust liquidity: 200 TON + 600,000 SDF
Initial ratio: 1 TON = 3,000 SDF
Metadata image: https://raw.githubusercontent.com/younissafa5555-maker/shadowfi-assets/main/shadowfi-sdf-logo.jpg

Transparency note: the jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended configuration is a transparent, time-limited 160-hour lock with `paused=false` and automatic reopening after `lockedUntil`. While active, ordinary SDF transfers into the DeDust jetton vault are rejected; the designated liquidity-manager deposit flow remains exempt so liquidity operations can complete. This capability is disclosed intentionally and is not intended as a permanent or hidden restriction.