### PR TITLE
Add DECKER jetton

### DIFF
--- a/jettons/DECKER.yaml
+++ b/jettons/DECKER.yaml
@@ -1,0 +1,8 @@
+name: DECKER
+symbol: DECKER
+address: EQB2-6mOs-Okm-FvtGJtY63D3C8Z81WCXkP03S_PKLcKOIjg
+decimals: 9
+description: Decking through cyberspace, connecting the dots in the digital realm.
+image: "https://download.decker.im/jetton/decker.png"
+websites:
+  - "https://decker.im"


### PR DESCRIPTION
Adding a new jetton - one new file, `jettons/DECKER.yaml`. No auto-generated `.json` files touched, no
  `ton.api` links; the image is a direct link to a 256x256 PNG.

  ```yaml
  address: EQB2-6mOs-Okm-FvtGJtY63D3C8Z81WCXkP03S_PKLcKOIjg
  symbol: DECKER
  websites:
    - "https://decker.im"
  ```

  All fields match the on-chain jetton content:
  https://tonviewer.com/EQB2-6mOs-Okm-FvtGJtY63D3C8Z81WCXkP03S_PKLcKOIjg
  Admin is the zero address, so minting is renounced and the supply is fixed at 777,777 DECKER.