### PR TITLE
Add Smartbit (SRT) jetton

### DIFF
--- a/jettons/$SRT.yaml
+++ b/jettons/$SRT.yaml
@@ -1,0 +1,5 @@
+name: Smartbit
+description: Smartbit (SRT) on TON. Includes transparent time-limited sell control for the DeDust vault; when enabled, the lock expires automatically.
+image: https://raw.githubusercontent.com/younissafa5555-maker/smartbit-assets/main/metadata/smartbit-srt.jpg
+address: EQDKAnAv_yMbrPsKbGCcbNg4mp-jFNzezBdlsrfkEuuMC19P
+symbol: SRT


### PR DESCRIPTION
Adds Smartbit (SRT) to the jetton registry.

Jetton master: `EQDKAnAv_yMbrPsKbGCcbNg4mp-jFNzezBdlsrfkEuuMC19P`

The token includes a transparent, time-limited sell-control capability for the DeDust vault. When enabled, the lock is designed to expire automatically.