### PR TITLE
Add BlackPill (BP) jetton

### DIFF
--- a/jettons/$BP.yaml
+++ b/jettons/$BP.yaml
@@ -1,0 +1,10 @@
+name: BlackPill
+description: "BlackPill (BP) — community meme token for the self-improvement space, connected to the FaceRate project. Ownership revoked, supply fixed, part of the liquidity permanently locked."
+image: "https://realfactchecknews-eng.github.io/blackpill-assets/logo.png"
+address: EQCfA0ixAvzRFd9_0sHZto0nPUnLh9ahvd4EnUBoCz2qqpHW
+symbol: BP
+decimals: 9
+websites:
+  - "https://facerate.ru"
+social:
+  - "https://t.me/bp_ton"

--- a/jettons/$BP.yaml
+++ b/jettons/$BP.yaml
@@ -1,10 +1,10 @@
 name: BlackPill
-description: "BlackPill (BP) — community meme token for the self-improvement space, connected to the FaceRate project. Ownership revoked, supply fixed, part of the liquidity permanently locked."
+description: "BlackPill (BP) — community meme token for the self-improvement and looksmaxxing space. Ownership revoked, supply fixed, part of the liquidity permanently locked."
 image: "https://realfactchecknews-eng.github.io/blackpill-assets/logo.png"
 address: EQCfA0ixAvzRFd9_0sHZto0nPUnLh9ahvd4EnUBoCz2qqpHW
 symbol: BP
 decimals: 9
 websites:
-  - "https://facerate.ru"
+  - "https://looks-max.ru"
 social:
   - "https://t.me/bp_ton"


### PR DESCRIPTION
Adding metadata for the BlackPill (BP) jetton.

**Contract:** `EQCfA0ixAvzRFd9_0sHZto0nPUnLh9ahvd4EnUBoCz2qqpHW`
[tonviewer](https://tonviewer.com/EQCfA0ixAvzRFd9_0sHZto0nPUnLh9ahvd4EnUBoCz2qqpHW)

- **Ownership revoked** — admin is set to the zero address, so the supply is fixed at 1,000,000,000 BP and the metadata can no longer be changed ([tx](https://tonviewer.com/transaction/f4835234c5549aaf3da6f2c842f7816963fe45ef988ee9c57219ebe0fdc5c452))
- **Liquidity:** BP/GRAM pool, 50% of the LP is permanently locked
- **Logo:** direct link to a 512x512 PNG hosted on GitHub Pages
- **Website:** https://looks-max.ru
- **Community:** https://t.me/bp_ton

BP is a standalone meme/community token around the looksmaxxing and self-improvement space, and is not presented as a financial instrument.