### PR TITLE
Add ONE jetton

### DIFF
--- a/jettons/$ONE.yaml
+++ b/jettons/$ONE.yaml
@@ -1,0 +1,4 @@
+symbol: ONE
+address: EQB4OloeRqCu_7kUjRS-_3rizPaEYsFLNhelYT42nxFn6Dcn
+name: "ONE"
+decimals: 18


### PR DESCRIPTION
Adding `ONE` jetton.

- Jetton master: `EQB4OloeRqCu_7kUjRS-_3rizPaEYsFLNhelYT42nxFn6Dcn`
- Symbol: ONE, decimals: 18
- Ownership revoked (admin is the zero address), metadata is on-chain and immutable
- Logo is a direct link to a .png file: https://realfactchecknews-eng.github.io/one-token-assets/logo.png
- Liquidity on DeDust (ONE/GRAM, CPMM v2), LP permanently locked

Only `jettons/$ONE.yaml` was added; no generated .json files were touched.