### PR TITLE
Add MeataDEX (MTX)

### DIFF
--- a/jettons/$MTX.yaml
+++ b/jettons/$MTX.yaml
@@ -1,0 +1,5 @@
+name: MeataDEX
+description: MeataDEX (MTX) on TON. Includes transparent time-limited sell control for the DeDust vault; when enabled, the lock expires automatically.
+image: https://raw.githubusercontent.com/younissafa5555-maker/meatadex-assets/main/metadata/meatadex-mtx.jpg
+address: EQDDqLIk8gs2eOL-LX2N6HL7v8aYrcTESjwhDZm6IlMjzZN5
+symbol: MTX


### PR DESCRIPTION
Adds registry metadata for MeataDEX (MTX) on TON.

Jetton master: EQDDqLIk8gs2eOL-LX2N6HL7v8aYrcTESjwhDZm6IlMjzZN5
Symbol: MTX

Disclosure: this Jetton includes a transparent, time-limited sell-control mechanism intended for the DeDust vault. When enabled, the lock is temporary and expires automatically; it is not a permanent or hidden sell restriction.