### PR TITLE
Fix LEEK contract address

### DIFF
--- a/jettons/LEEK.yaml
+++ b/jettons/LEEK.yaml
@@ -1,6 +1,6 @@
 name: "GramLeek"
 symbol: "LEEK"
-address: "EQAm0QqDz6woBJ1dvwF114PHdD6CE3eVMd58INFRKp3n9Ycw"
+address: "EQAmoQqDz6woBJ1dvwFl14PHdD6CE3eVMd58INFRKp3n9Ycw"
 description: "Not a vegetable."
 image: "https://raw.githubusercontent.com/GramLeek/Assets/refs/heads/main/Logo.png"
 social:


### PR DESCRIPTION
Correcting the jetton master address in LEEK.yaml. Previous submission contained a typo in the contract address.