### PR TITLE
Add NebuLaForge NAR jetton

### DIFF
--- a/jettons/NAR.yaml
+++ b/jettons/NAR.yaml
@@ -1,0 +1,5 @@
+name: NebuLaForge
+description: NebuLaForge (NAR) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/nebulaforge-assets/main/nebulaforge-nar-logo.jpg
+address: EQDwrnPrr3bhayx966f88xibXk6EqdmD-TlZougBF7EDuMSn
+symbol: NAR


### PR DESCRIPTION
Adds NebuLaForge (NAR) to the Tonkeeper jetton registry.

Jetton master: `EQDwrnPrr3bhayx966f88xibXk6EqdmD-TlZougBF7EDuMSn`
Total supply: 120,000,000 NAR
Decimals: 9
Minting: permanently closed
Initial DeDust liquidity: 200 TON + 6,000,000 NAR
Initial ratio: 1 TON = 30,000 NAR
Metadata image: https://raw.githubusercontent.com/younissafa5555-maker/nebulaforge-assets/main/nebulaforge-nar-logo.jpg

Transparency note: the jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended configuration is a transparent, time-limited 168-hour lock with `paused=false` and automatic reopening after `lockedUntil`. While active, ordinary NAR transfers into the DeDust jetton vault are rejected; the designated liquidity-manager deposit flow remains exempt so liquidity operations can complete. This capability is disclosed intentionally and is not intended as a permanent or hidden restriction.