### PR TITLE
Add Bull Run BULL Jetton

### DIFF
--- a/jettons/bull-run.yaml
+++ b/jettons/bull-run.yaml
@@ -1,0 +1,12 @@
+name: "BULL"
+symbol: "BULL"
+address: "EQAM216saJrl06iMxrCwyDZsAPAeWJF8GdWwD3EWtLit-qS0"
+description: "BULL is the native Jetton of Bull Run, a Telegram-native Web3 game built on The Open Network (TON)."
+image: "https://bullrungame.app/static/bull.jpg"
+social:
+  - "https://x.com/BULLRUNwallst"
+  - "https://t.me/BullRunChanell"
+websites:
+  - "https://bull-run-15q.pages.dev/"
+  - "https://github.com/omdysfii/bull-Run"
+decimals: 9


### PR DESCRIPTION
## Bull Run BULL Jetton

This pull request adds a new BULL Jetton entry for Bull Run.

- Name: BULL
- Symbol: BULL
- Network: The Open Network (TON)
- Jetton Master: EQAM216saJrl06iMxrCwyDZsAPAeWJF8GdWwD3EWtLit-qS0
- Website: https://bull-run-15q.pages.dev/
- GitHub: https://github.com/omdysfii/bull-Run
- X: https://x.com/BULLRUNwallst
- Telegram: https://t.me/BullRunChanell

### Project Status

Bull Run is currently in the pre-launch phase.
Public token distribution has not yet started, so the current number of BULL holders is limited.

The holder count is expected to grow naturally as the project launches and BULL becomes available to users.

This is a new Jetton entry and does not modify the existing BULL token entry in the repository.