### PR TITLE
Add Cryonex COX jetton

### DIFF
--- a/jettons/COX.yaml
+++ b/jettons/COX.yaml
@@ -1,0 +1,5 @@
+name: Cryonex
+description: Cryonex (COX) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/cryonex-assets/main/cryonex-cox-logo.jpg
+address: EQDTGHDNEkDWocMp9oAVSxiPZaa4cSUUmYD5Cuo004fFmIk7
+symbol: COX


### PR DESCRIPTION
## Cryonex (COX)

- Jetton master: `EQDTGHDNEkDWocMp9oAVSxiPZaa4cSUUmYD5Cuo004fFmIk7`
- Total supply: `120,000,000 COX`
- Decimals: `9`
- Minting: permanently closed (`mintable=false`)
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/cryonex-assets/main/cryonex-cox.json
- Image: https://raw.githubusercontent.com/younissafa5555-maker/cryonex-assets/main/cryonex-cox-logo.jpg

## Initial DeDust liquidity

- Pool type: `VOLATILE`
- Pool: `EQAEOkxDC7SVFTHF9WNalpTylZLIyGTfQYGSOTCGYhfzdGnM`
- Liquidity: `200 TON + 600,000 COX`
- Initial ratio: `1 TON = 3,000 COX`

The project created only this one COX/TON volatile pool. DeDust is permissionless, so third parties may independently create other pools.

## Sell-control transparency disclosure

The custom jetton-wallet contract includes an admin-controlled sell-control capability.

At the time of this PR, the capability is disabled:
- `enabled=false`
- `paused=false`
- `lockedUntil=0`
- `sellOpen=true`

After this PR is submitted, the intended configuration is a transparent, time-limited `167-hour` sell lock:
- `enabled=true`
- `paused=false`
- automatic reopening after `lockedUntil`
- while active, ordinary COX transfers into the designated DeDust Jetton Vault are rejected
- the designated liquidity-manager deposit path is exempt

This feature is time-limited, disclosed here, and is not intended as a permanent or hidden restriction.