### PR TITLE
Add tgcoin (KZTg) — KZT-pegged stablecoin

### DIFF
--- a/jettons/KZTg.yaml
+++ b/jettons/KZTg.yaml
@@ -7,4 +7,4 @@ address: 0:e9ba9f29d832a33eb7fd3e4d92bfa9aa544ed1da4b5c819eabd2f9649422f0a6
 websites:
   - "https://tgcoin.kz"
 social:
-  - "https://t.me/tgcoin_wallet_bot"
+  - "https://tgcoin.kz"

--- a/jettons/KZTg.yaml
+++ b/jettons/KZTg.yaml
@@ -1,0 +1,10 @@
+name: tgcoin
+symbol: KZTg
+description: Regulated stablecoin pegged 1:1 to the Kazakhstani tenge (KZT), issued on TON for Kazakhstan users of Telegram @wallet. Supply is minted and burned only through the issuer's treasury.
+image: "https://tgcoin.kz/jetton/logo.png"
+decimals: 9
+address: 0:e9ba9f29d832a33eb7fd3e4d92bfa9aa544ed1da4b5c819eabd2f9649422f0a6
+websites:
+  - "https://tgcoin.kz"
+social:
+  - "https://t.me/tgcoin_wallet_bot"


### PR DESCRIPTION
## tgcoin (KZTg)

**What it is.** A regulated stablecoin pegged 1:1 to the Kazakhstani tenge (KZT), issued on TON for Kazakhstan users of Telegram. The project is prepared within the special regulatory regime (regulatory sandbox) of the National Bank of the Republic of Kazakhstan.

**Jetton minter:** `EQDpup8p2DKjPrf9Pk2Sv6mqVE7R2ktcgZ6r0vlklCLwph_G`  
raw: `0:e9ba9f29d832a33eb7fd3e4d92bfa9aa544ed1da4b5c819eabd2f9649422f0a6`

- tonviewer: https://tonviewer.com/EQDpup8p2DKjPrf9Pk2Sv6mqVE7R2ktcgZ6r0vlklCLwph_G
- Source code verified: https://verifier.ton.org/EQDpup8p2DKjPrf9Pk2Sv6mqVE7R2ktcgZ6r0vlklCLwph_G (Tolk; compiles to the on-chain bytecode)
- TEP-64 metadata: https://tgcoin.kz/jetton/meta.json (served with CORS)
- Logo (PNG, direct link): https://tgcoin.kz/jetton/logo.png
- Website: https://tgcoin.kz — see the "The token on TON" and "Verify it yourself" sections


**How the token works.** tgcoin is a permissioned TEP-74 jetton: supply is minted only by the issuer's admin wallet into the platform treasury and burned only from that treasury (1 KZT received = 1 KZTg minted; redemption burns). Holder jetton wallets are activated by the issuer after the customer passes KYC (biometric liveness + state identity registry) and PEP/sanctions screening; transfers to non-activated wallets bounce back safely. This is intentional and required for operating a stablecoin under Kazakhstan's regulatory requirements, and is explained on the website.

**Metadata:** name `tgcoin`, symbol `KZTg`, decimals `9`.

Happy to answer any questions or provide additional documentation in this thread.
