### PR TITLE
Correct $GSC description — it claims GSC is required for access, which it is not

### DIFF
--- a/jettons/$GSC.yaml
+++ b/jettons/$GSC.yaml
@@ -1,7 +1,7 @@
 name: "Gram super cycle"
 symbol: "GSC"
 address: "EQAmaMdwCmpZNJSRfvbNZDu1HkjFbw2VtvvI1FDKvLJMgyXE"
-description: "The reward token of Saturn, the capital house on TON. Rewards from Saturn's liquidity farm are paid in GSC. Supply is one billion, fixed; mint authority is renounced."
+description: "The reward token of Saturn, the capital house on TON. Farm rewards are paid in GSC, and some launch rounds are gated on holding it. Supply is one billion, fixed; mint authority is renounced."
 image: "https://saturn.tg/tokens/gsc.png"
 social:
   - "https://saturn.tg"

--- a/jettons/$GSC.yaml
+++ b/jettons/$GSC.yaml
@@ -1,8 +1,8 @@
 name: "Gram super cycle"
 symbol: "GSC"
 address: "EQAmaMdwCmpZNJSRfvbNZDu1HkjFbw2VtvvI1FDKvLJMgyXE"
-description: "The coin of the #GRAMSUPERCYCLE. Powers Saturn, the capital house on TON — membership, launch access and commit capacity are all held in $GSC."
+description: "The reward token of Saturn, the capital house on TON. Rewards from Saturn's liquidity farm are paid in GSC. Supply is one billion, fixed; mint authority is renounced."
 image: "https://saturn.tg/tokens/gsc.png"
 social:
   - "https://saturn.tg"
-  - "https://t.me/hollowjournal"
+  - "https://t.me/saturndottg"


### PR DESCRIPTION
Correcting the `$GSC` entry. We are the token's team — this fixes a description of our own that overstates, and the wallet catalog is the only place we can still change it.

**Two changes.**

**1 · The description says GSC is required for everything. It is required for some things.**

The current text reads *"membership, launch access and commit capacity are all held in $GSC."* Most of Saturn works with no GSC at all — swapping, providing liquidity, farming, applying to launch and claiming airdrops require none of it, and launch rounds have run on invited and community gates.

What is true is narrower: **holding GSC has gated entry to launch rounds** — one DIGGY round was gated on holdings and drew 62 participants — and **farm rewards are paid in GSC**. Replaced with:

> The reward token of Saturn, the capital house on TON. Farm rewards are paid in GSC, and some launch rounds are gated on holding it. Supply is one billion, fixed; mint authority is renounced.

The supply clauses are verifiable on-chain in one call: `total_supply` 1000000000000000000 at 9 decimals = 1,000,000,000; `mintable: false`; `admin: null`.

**Why we cannot fix this at the source:** the jetton's metadata is an off-chain pointer to an immutable IPFS CID and the mint authority is renounced, so the on-chain description is frozen. This repo is the only place corrected text can reach a wallet.

**2 · The Telegram link points at the wrong channel.**

`t.me/hollowjournal` is a personal channel, not the token's. Changed to `t.me/saturndottg`, Saturn's announcement channel.

---

Edited `jettons/$GSC.yaml` only, per the README — no `.json` files touched. The image link is unchanged, already a direct `.png` and not on ton.api.

*Edited after opening: an earlier version of this description and of this note said the holding-gated round type had never been used. That was wrong — a DIGGY round used it on 2026-08-26. The overstatement in the original text is "all", not the gate itself, and the description now says so.*
