### PR TITLE
Add CELESTIUM (CLM) jetton

### DIFF
--- a/jettons/CLM.yaml
+++ b/jettons/CLM.yaml
@@ -1,0 +1,5 @@
+name: CELESTIUM
+description: CELESTIUM (CLM) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/celestium-assets/main/celestium-clm-logo.jpg
+address: EQB0-wrEGl7hd5mBYDepD0wSWHQECFwBtzIKipyDJsUc0ecQ
+symbol: CLM


### PR DESCRIPTION
## Token information

- Name: CELESTIUM
- Symbol: CLM
- Jetton Master: `EQB0-wrEGl7hd5mBYDepD0wSWHQECFwBtzIKipyDJsUc0ecQ`
- Decimals: 9
- Total supply: 120,000,000 CLM
- Minting: permanently closed
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/celestium-assets/main/celestium-clm.json
- Image: https://raw.githubusercontent.com/younissafa5555-maker/celestium-assets/main/celestium-clm-logo.jpg
- DeDust volatile pool: `EQAGRCnvfYIlWjKJn-_ugclUzN8xiodT-pi5q_0r55wLHDRk`
- Active liquidity: 200 TON / 6,000,000 CLM

## Transparency note

The jetton-wallet contract includes an admin-controlled sell-control capability. It is currently disabled. The intended use is a transparent, time-limited 167-hour lock with `paused=false` and automatic reopening after the configured timestamp. While this timed lock is active, ordinary token transfers into the DeDust jetton vault are rejected, while the designated liquidity-manager deposit flow remains exempt.