### PR TITLE
Add JPEGPE jetton metadata

### DIFF
--- a/jettons/JPEGPE.yaml
+++ b/jettons/JPEGPE.yaml
@@ -1,0 +1,7 @@
+name: JPEGPE
+description: "Some stories don't start with an announcement. They just appear 🐸"
+address: EQAmYU1sd0IKbfW8JOMppwaGsgvvxdTOIo6TvUy1IJZ5sV8j
+symbol: JPEGPE
+social:
+  - "https://t.me/jpegpecoin"
+  - "https://t.me/jpegpecoinchat"


### PR DESCRIPTION
Add JPEGPE jetton metadata for wallet and explorer recognition on TON mainnet.

- Jetton master: `EQAmYU1sd0IKbfW8JOMppwaGsgvvxdTOIo6TvUy1IJZ5sV8j`
- Name / symbol: JPEGPE
- Official channel: https://t.me/jpegpecoin
- Community: https://t.me/jpegpecoinchat
- Explorer: https://tonviewer.com/EQAmYU1sd0IKbfW8JOMppwaGsgvvxdTOIo6TvUy1IJZ5sV8j

The name, symbol and description follow the existing on-chain metadata (description whitespace and apostrophe normalized). TONAPI reports 9 decimals, a total supply of 1,000,000,000 and mintable=false.

No image override is supplied: the on-chain image is already an IPFS URI. The public gateway URL in our earlier draft could not be revalidated, so this request does not introduce that override or a ton.api image URL.

Only `jettons/JPEGPE.yaml` is added. This request is for asset recognition, not a claim about price, liquidity or an audit.
