### PR TITLE
Add VIREXA (VRX) jetton

### DIFF
--- a/jettons/VRX.yaml
+++ b/jettons/VRX.yaml
@@ -1,0 +1,5 @@
+name: VIREXA
+description: VIREXA (VRX) on TON
+image: https://raw.githubusercontent.com/younissafa5555-maker/virexa-assets/main/virexa-vrx-logo.jpg
+address: EQCFPkld8Rql8XNdHdteJGZ_W4Z2n2a_urLm3KgWmYwxV_8I
+symbol: VRX


### PR DESCRIPTION
Adds VIREXA (VRX) to the jetton registry.

Jetton Master: EQCFPkld8Rql8XNdHdteJGZ_W4Z2n2a_urLm3KgWmYwxV_8I
Decimals: 9
Total supply: 120,000,000 VRX
Minting permanently closed, confirmed by getter.
DeDust pool: EQChLEQTQiqh5Wzh41bIZfwAq-nLOIUWoSriAR9oyK0xw9Ap
Observed reserves: 195 TON and 11,700,000 VRX.
Metadata: https://raw.githubusercontent.com/younissafa5555-maker/virexa-assets/main/virexa-vrx.json
Image: https://raw.githubusercontent.com/younissafa5555-maker/virexa-assets/main/virexa-vrx-logo.jpg

Transparency note: the jetton-wallet contract includes admin-controlled transfer restrictions. The operator's post-transaction getter output confirms that the lock is now enabled on the DeDust vault jetton wallet EQAoYOO0rUCESnJxvDka59-70Gz2XeaViqD74q59uFtv-Jme: enabled=true, paused=false, sellOpen=false, lockedUntil=1789391055. The configured duration was 167 hours; the deadline is 2026-09-14 13:04:15 UTC. The inspected admin wallet remains enabled=false and sellOpen=true; this does not exempt ordinary admin sells into the locked vault. This is getter confirmation of the configured state, not a completed behavioral test of reopening. During that lock, ordinary incoming transfers to this wallet, including sells through this vault, are rejected. Outgoing transfers are not blocked by this control, so buys can remain possible. The designated liquidity-manager deposit flow is exempt.

The modified contract limits activation to once per wallet, with a maximum duration of 167 hours from activation. Extension and manual pausing are rejected; the time condition stops blocking transfers after the deadline. These limits apply per wallet, not globally across all wallets. The contract does not independently authenticate that an admin-selected target owner is a DeDust vault. Lock behavior has not yet been validated with dedicated behavioral tests.

This PR changes only jettons/VRX.yaml.
