### PR TITLE
Add VOLTARIS (VLT)

### DIFF
--- a/jettons/VLT.yaml
+++ b/jettons/VLT.yaml
@@ -1,0 +1,5 @@
+name: VOLTARIS
+description: "VOLTARIS (VLT) on TON. Includes an admin-activated, one-time timed restriction on transfers into the designated DeDust vault wallet, planned for 167 hours and capped at 168 hours per wallet. Admin liquidity deposits are exempt. The restriction expires automatically and cannot be extended or reactivated on that wallet."
+image: "https://raw.githubusercontent.com/younissafa5555-maker/voltaris-assets/main/voltaris-vlt.jpg"
+address: EQCcrcO28PSRvRQIlsHcQaz4dDoUyapydEq8hCQYySlWaXKM
+symbol: VLT


### PR DESCRIPTION
Add VOLTARIS (VLT) to the jetton registry. Only jettons/VLT.yaml is changed.

Token details:
- Network: TON mainnet
- Jetton Master: EQCcrcO28PSRvRQIlsHcQaz4dDoUyapydEq8hCQYySlWaXKM
- Decimals: 9
- Total supply: 120,000,000 VLT
- Minting permanently closed, confirmed by get_jetton_data.
- DeDust pool: EQCJ7RQ692cViAHvUIWaJbnYRaX4fMJeyLOasB9H7JN-zR89
- Verified reserves at the latest check: 200 TON and 3,000,000 VLT.
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/voltaris-assets/main/voltaris-vlt.json
- Logo: https://raw.githubusercontent.com/younissafa5555-maker/voltaris-assets/main/voltaris-vlt.jpg

Transparency note:
The jetton-wallet contract includes an admin-controlled incoming-transfer restriction. At the latest on-chain check it was disabled on both the DeDust vault jetton wallet and the admin jetton wallet. The intended activation is a 167-hour restriction on ordinary incoming transfers to the DeDust vault jetton wallet, which prevents sells through that vault. Admin liquidity deposits with the designated DeDust deposit opcode remain exempt.

The contract requires paused=false and a future unlock timestamp no more than 168 hours from activation. Once activated on a wallet, the restriction cannot be extended, disabled early, or activated again on that wallet. Transfers become permitted automatically at the timestamp. The designated liquidity manager must be the admin.

Scope of admin authority: the vaultOwner field is supplied by the admin and checked against the target wallet owner; the contract does not independently restrict activation to the official DeDust vault. The one-time limit applies per jetton wallet, not globally. The admin also retains metadata-update authority.

The timed-lock and holder-transfer behavior was tested locally, including rejection during the lock, bounced token balance restoration, and successful transfer at expiry. These tests are not an independent security audit.


Post-activation update:
The planned timed restriction has now been activated and confirmed by the on-chain getter on vault jetton wallet EQDOv7-jC-ZKCjiXyoi7e8X8jCkZ6gtmB7Ef3G34g-7KzSl2.
Confirmed state: enabled=true, paused=false, sellOpen=false, lockedUntil=1789410100.
Automatic unlock: 2026-09-14 18:21:40 UTC. The earlier disabled-state observation above was before activation.
Admin wallet sell control remains disabled. Ordinary transfers from the admin into the restricted vault are also rejected; only the designated admin liquidity-deposit flow is exempt.
