### PR TITLE
Add YOLKY the EGG (EQA6VwWHQ60...) with its logo

### DIFF
--- a/jettons/YOLKYtheEGG.yaml
+++ b/jettons/YOLKYtheEGG.yaml
@@ -1,0 +1,9 @@
+name: YOLKY the EGG
+description: The token of the Yolky product suite on Telegram and TON. Product revenue goes to the treasury, which buys YOLKY back on the open market.
+image: "https://yolkytheegg.com/assets/img/logo-yolky-round.png"
+address: EQA6VwWHQ60exmvkLnjYLgy5Qke4X0lKz5n516JnL8yLEv8F
+symbol: YOLKY
+websites:
+  - "https://yolkytheegg.com"
+social:
+  - "https://t.me/yolkytheegg"

--- a/jettons/imported_from_dex.yaml
+++ b/jettons/imported_from_dex.yaml
@@ -1625,9 +1625,6 @@
 - address: 0:519b0b875dab7c0623a09246ab0a4ec7b9c4418dcc8e6fc79fc0eb93e3909e72
   name: Meme Inc
   symbol: YOBA
-- address: 0:3a57058743ad1ec66be42e78d82e0cb94247b85f494acf99f9d7a2672fcc8b12
-  name: YOLKY the EGG
-  symbol: YOLKY
 - address: 0:a7658ce69ae845b6d34492b51937d3621e1b2a6c1208c72633856d6c255b1901
   name: The Reversed Livaz
   symbol: ZAVIL


### PR DESCRIPTION
### What this does

Adds `jettons/YOLKYtheEGG.yaml` for **YOLKY the EGG** (`EQA6VwWHQ60exmvkLnjYLgy5Qke4X0lKz5n516JnL8yLEv8F`) and removes its duplicate three-line stub from `jettons/imported_from_dex.yaml`.

### Why

The jetton is currently listed only through `imported_from_dex.yaml`, with address, name and symbol and no image, so it renders with the generic token placeholder.

The image is already published on chain. The content is semi-chain: the on-chain dictionary holds `decimals` and a `uri` pointing to `ipfs://bafkreigxvtecwdckph7icqm566tghcbelqx62dtlbbz55qh3pr3oio23mu`, and that JSON carries the name, description, symbol and an `image` at `ipfs://bafkreietxzleig55fcfzxrenw6fzeumgcqmulkbj3gzmfm5dpdwdqbuztq` (256x256, the same artwork). This PR only brings the curated entry in line with what the contract already says.

### Notes for review

- The image link is a direct `.png` on the project's own domain, not a webpage and not a ton.api URL, per the README.
- Filed as `YOLKYtheEGG.yaml` rather than `YOLKY.yaml` because `jettons/YOLKY.yaml` is a **different jetton** (`EQAmDS3NS9BCLSP4djrt_B8vaSdJvV5JcrL4rMd___BFyVaH`) that shares the ticker. This PR does not touch that file.
- Only the two `jettons/` files are changed. No generated `.json` is touched.

Jetton: https://tonviewer.com/EQA6VwWHQ60exmvkLnjYLgy5Qke4X0lKz5n516JnL8yLEv8F
Site: https://yolkytheegg.com
