### PR TITLE
Add STONBEX (SNX)

### DIFF
--- a/jettons/SNX.yaml
+++ b/jettons/SNX.yaml
@@ -1,0 +1,6 @@
+name: STONBEX
+description: "STONBEX (SNX) on TON. Includes an admin-activated incoming-transfer restriction, planned for 167 hours on the DeDust vault jetton wallet. The contract caps each wallet restriction at 168 hours, permits only one activation per wallet, and automatically reopens transfers at expiry. Extension and early reopening are not supported. Designated admin liquidity deposits are exempt. Admin targeting is not restricted on-chain to DeDust vaults; metadata remains admin-updatable."
+image: "https://raw.githubusercontent.com/younissafa5555-maker/stonbex-assets/main/stonbex-snx.jpg"
+address: EQBmME_yViOJvB-f8DZtH8REHRllLPJeC2u_OYPGn5Nn__Zp
+symbol: SNX
+decimals: 9


### PR DESCRIPTION
Add STONBEX (SNX) to the jetton registry. Only jettons/SNX.yaml is changed.

Token details:
- Network: TON mainnet
- Jetton master: EQBmME_yViOJvB-f8DZtH8REHRllLPJeC2u_OYPGn5Nn__Zp
- Decimals: 9
- Total supply at the last check: 120,000,000 SNX
- Minting permanently closed, confirmed by get_jetton_data.
- DeDust pool: EQB6gniTb4L3aAhJ9K7OKisLVxiIRPQMKYu4pw7FHl0R0wp8
- Reserves at the last check: 200 TON and 900,000 SNX.
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/stonbex-assets/main/stonbex-snx.json
- Logo: https://raw.githubusercontent.com/younissafa5555-maker/stonbex-assets/main/stonbex-snx.jpg

Transparency note:
The jetton-wallet contract includes an admin-activated incoming-transfer restriction. At the last getter check, sell control was disabled on both the DeDust vault jetton wallet and the admin jetton wallet. A 167-hour restriction is planned for the DeDust vault jetton wallet EQBLQuNV9sfRQDLTwTiUkF3cnlfw-5IOuq453_TDCOYk-MMX.

When activated, ordinary incoming transfers to that wallet are rejected, preventing sells through that vault. Ordinary admin transfers are also restricted; only the designated admin liquidity-deposit flow is exempt.

The contract requires paused=false and a future unlock timestamp no more than 168 hours from activation. The restriction automatically expires at that timestamp and cannot be extended, disabled early, or activated again on the same wallet.

The admin supplies vaultOwner; the contract does not independently limit activation to official DeDust vaults. The one-time limit applies per jetton wallet, not globally. The designated liquidity manager must be the admin. Metadata-update authority remains with the admin.

Local sandbox tests passed for timed-lock limits, authorization, blocked holder transfers with bounced balance restoration, reopening at expiry, and rejection of relocking. These tests are not an independent security audit.


Post-activation update:
The planned timed restriction has now been activated and confirmed by the on-chain getter on vault jetton wallet EQBLQuNV9sfRQDLTwTiUkF3cnlfw-5IOuq453_TDCOYk-MMX.
Confirmed state: enabled=true, paused=false, sellOpen=false, lockedUntil=1789578717.
Automatic unlock: 2026-09-16 17:11:57 UTC. The earlier disabled-state observation above was before activation.
Admin wallet sell control remains disabled. Ordinary admin transfers into the restricted vault are also rejected; only the designated admin liquidity-deposit flow is exempt.
