### PR TITLE
Add GRAM jetton and remove false-positive blacklist

### DIFF
--- a/jettons/GRAM-10M.yaml
+++ b/jettons/GRAM-10M.yaml
@@ -1,0 +1,7 @@
+name: "GRAM"
+symbol: "GRAM"
+address: "0:e7249e065078fce0cd7025e332e65406e6998de2164323a389cbeedf2a083855"
+description: "GRAM is an independent utility token on The Open Network (TON) for transfers, community rewards, and Web3 applications. It is not affiliated with Tether, USDT, Toncoin, or the TON Foundation."
+image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png"
+websites:
+  - "https://github.com/1003conca-cpu/gram-token-assets"


### PR DESCRIPTION
## Request

Please review this Jetton and remove the current false-positive blacklist classification.

## Jetton

- Name: GRAM
- Symbol: GRAM
- Master: `0:e7249e065078fce0cd7025e332e65406e6998de2164323a389cbeedf2a083855`
- Supply: 10,000,000 GRAM
- Network: TON Mainnet
- Logo: https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png

## Reason for appeal

An earlier version of the on-chain metadata used the name `GRAM(USDT)` and referenced USDT/Tether. That metadata has been permanently corrected.

The current on-chain metadata now clearly identifies GRAM as an independent utility token and explicitly states that it is not affiliated with Tether, USDT, Toncoin, or the TON Foundation.

The Jetton master is active, its metadata and logo are publicly accessible, it has holders, and it has an active DeDust liquidity pool.

## DeDust pool

- Pool: `0:145b23a3989483fb7fdc8a47b6a7b8ce6b8f64cdebf2f204bf1ae7cfbadab81b`
- Current reserves: 2 GRAM / 2.60 USD₮

Please re-review the asset and remove the blacklist classification.