### PR TITLE
Add GramMiners mineral jettons

### DIFF
--- a/jettons/GramMiners-cyan.yaml
+++ b/jettons/GramMiners-cyan.yaml
@@ -1,0 +1,8 @@
+name: "GramMiners Cyan"
+description: "Cyan mineral token for GramMiners, represented by elongated blue crystals."
+image: "https://gramminers-dton.magic.org/assets/jettons/7d0bd711d35e14bd66cf/icons/cyan.png"
+address: "0:ed9f44a932e104c0bbb8b297819de9f1f210b76b90b2c77e03c902096a0d9614"
+symbol: "GMCY at gramminers.ton"
+decimals: 0
+websites:
+  - "https://gramminers-dton.magic.org"

--- a/jettons/GramMiners-garnet.yaml
+++ b/jettons/GramMiners-garnet.yaml
@@ -1,0 +1,8 @@
+name: "GramMiners Garnet"
+description: "Garnet mineral token for GramMiners, represented by dark-red faceted crystals."
+image: "https://gramminers-dton.magic.org/assets/jettons/7d0bd711d35e14bd66cf/icons/garnet.png"
+address: "0:be830adede5234805240d9db1ba7361af4ba881e14f74d6dcf422a6fe220420a"
+symbol: "GMGN at gramminers.ton"
+decimals: 0
+websites:
+  - "https://gramminers-dton.magic.org"

--- a/jettons/GramMiners-jadeite.yaml
+++ b/jettons/GramMiners-jadeite.yaml
@@ -1,0 +1,8 @@
+name: "GramMiners Jadeite"
+description: "Jadeite mineral token for GramMiners, represented by a pale mint mottled stone."
+image: "https://gramminers-dton.magic.org/assets/jettons/7d0bd711d35e14bd66cf/icons/jadeite.png"
+address: "0:277539c0d353dc7d904aeb25eff9aad2f9ba4d1861d6eddce8fb2819e4f97d19"
+symbol: "GMJD at gramminers.ton"
+decimals: 0
+websites:
+  - "https://gramminers-dton.magic.org"

--- a/jettons/GramMiners-nephrite.yaml
+++ b/jettons/GramMiners-nephrite.yaml
@@ -1,0 +1,8 @@
+name: "GramMiners Nephrite"
+description: "Nephrite mineral token for GramMiners, represented by an olive-green fibrous rough stone."
+image: "https://gramminers-dton.magic.org/assets/jettons/7d0bd711d35e14bd66cf/icons/nephrite.png"
+address: "0:654d48d8ecf6581c855fa0efc2aae6e6d775bb08d6db923f9a5ecc252ed80f86"
+symbol: "GMNP at gramminers.ton"
+decimals: 0
+websites:
+  - "https://gramminers-dton.magic.org"


### PR DESCRIPTION
Add the four GramMiners mineral jettons deployed on TON mainnet. The names, symbols, descriptions, decimals and direct PNG URLs match their current on-chain metadata.

Project: [GramMiners](https://gramminers-dton.magic.org) (gramminers.ton).

| Token | Symbol | Master contract |
| --- | --- | --- |
| GramMiners Cyan | `GMCY at gramminers.ton` | [EQDtn0SpMuEEwLu4speBnenx8hC3a5Cyx34DyQIJag2WFBxi](https://tonviewer.com/EQDtn0SpMuEEwLu4speBnenx8hC3a5Cyx34DyQIJag2WFBxi) |
| GramMiners Nephrite | `GMNP at gramminers.ton` | [EQBlTUjY7PZYHIVfoO_Cqubm13W7CNbbkj-aXswlLtgPhqyU](https://tonviewer.com/EQBlTUjY7PZYHIVfoO_Cqubm13W7CNbbkj-aXswlLtgPhqyU) |
| GramMiners Jadeite | `GMJD at gramminers.ton` | [EQAndTnA01PcfZBK6yXv-arS-bpNGGHW7dzo-ygZ5Pl9GYqI](https://tonviewer.com/EQAndTnA01PcfZBK6yXv-arS-bpNGGHW7dzo-ygZ5Pl9GYqI) |
| GramMiners Garnet | `GMGN at gramminers.ton` | [EQC-gwre3lI0gFJA2dsbpzYa9LqIHhT3TW3PQipv4iBCCjTR](https://tonviewer.com/EQC-gwre3lI0gFJA2dsbpzYa9LqIHhT3TW3PQipv4iBCCjTR) |

Each token uses zero decimals and currently has a total supply of 1,000 units. The minting and metadata administrator remains enabled. The images are served directly from the project website.

This PR adds only four source YAML files under `jettons/`; generated files are unchanged.

Validation: the unchanged upstream `python3 generator.py` completed successfully against base commit `913e0594012edc8e8c737ee6269b9c482523e0e6` under Python 3.12.3 with the original dependency versions. The source-directory check passed, and the generated jetton list adds exactly these four entries while preserving all existing entries.
