### PR TITLE
Add GRAM jetton asset

### DIFF
--- a/jettons/GRAM-10M.yaml
+++ b/jettons/GRAM-10M.yaml
@@ -2,5 +2,5 @@ name: GRAM
 symbol: GRAM
 address: 0:e7249e065078fce0cd7025e332e65406e6998de2164323a389cbeedf2a083855
 decimals: 9
-description: "GRAM is an independent utility token on The Open Network (TON) for transfers, community rewards, and Web3 applications."
+description: "GRAM is an independent project utility token on TON Mainnet for internal project use, transfers, community rewards, testing and Web3 applications. It is not fiat money, legal tender, a stablecoin, USDT, or issued by, affiliated with, or backed by Tether."
 image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png"

--- a/jettons/GRAM-10M.yaml
+++ b/jettons/GRAM-10M.yaml
@@ -1,0 +1,6 @@
+name: GRAM
+symbol: GRAM
+address: 0:e7249e065078fce0cd7025e332e65406e6998de2164323a389cbeedf2a083855
+decimals: 9
+description: "GRAM is an independent utility token on The Open Network (TON) for transfers, community rewards, and Web3 applications."
+image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png"


### PR DESCRIPTION
Please review and add this TON mainnet jetton to the asset registry.

Name: GRAM
Symbol: GRAM
Jetton master: UQDnJJ4GUHj84M1wJeMy5lQG5pmN4hZDI6OJy-7fKgg4VclV
Raw address: 0:e7249e065078fce0cd7025e332e65406e6998de2164323a389cbeedf2a083855
Decimals: 9
Logo: https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png

TonAPI currently marks this asset as blacklist. Please review the asset metadata and verification/risk status. Related issue: #6200.