### PR TITLE
Add TON GRAM 6M jetton asset

### DIFF
--- a/jettons/GRAM-6M.yaml
+++ b/jettons/GRAM-6M.yaml
@@ -1,0 +1,6 @@
+name: TON GRAM
+symbol: GRAM
+address: 0:93b0b926ddf7345752d5ac055e4936ca4af1809aacdad2af4399bede1829373e
+decimals: 9
+description: "TON GRAM is an independent project utility token on TON Mainnet for internal project use, transfers, community rewards, testing and Web3 applications. It is not fiat money, not legal tender, not a stablecoin, and is not issued by, affiliated with, or backed by Tether or USDT."
+image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-6m-logo.svg"

--- a/jettons/GRAM-6M.yaml
+++ b/jettons/GRAM-6M.yaml
@@ -3,4 +3,4 @@ symbol: GRAM
 address: 0:93b0b926ddf7345752d5ac055e4936ca4af1809aacdad2af4399bede1829373e
 decimals: 9
 description: "TON GRAM is an independent project utility token on TON Mainnet for internal project use, transfers, community rewards, testing and Web3 applications. It is not fiat money, not legal tender, not a stablecoin, and is not issued by, affiliated with, or backed by Tether or USDT."
-image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-6m-logo.svg"
+image: "https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png"


### PR DESCRIPTION
Please review and add this TON Mainnet project jetton to the asset registry.

Name: TON GRAM
Symbol: GRAM
Jetton master: EQCTsLkm3fc0V1LVrAVeSTbKSvGAmqza0q9Dmb7eGCk3PtiO
Raw address: 0:93b0b926ddf7345752d5ac055e4936ca4af1809aacdad2af4399bede1829373e
Decimals: 9
Logo: https://raw.githubusercontent.com/1003conca-cpu/gram-token-assets/main/gram-logo.png

Project context: independent project utility token for internal project use, transfers, community rewards, testing and Web3 applications. It is not fiat money, not legal tender, not a stablecoin, and is not issued by, affiliated with, or backed by Tether/USDT.

The branch now uses the existing canonical PNG asset. TonAPI currently marks this asset as blacklist; please manually review the metadata and risk/verification status together with related issue #6202.

This PR changes registry metadata only and does not perform or authorize any on-chain transaction.