### PR TITLE
Add VULMO (VLO)

### DIFF
--- a/jettons/VLO.yaml
+++ b/jettons/VLO.yaml
@@ -1,0 +1,6 @@
+name: VULMO
+description: "VULMO (VLO) on TON. Includes an admin-activated incoming-transfer restriction, planned for 167 hours on the DeDust vault jetton wallet, preventing sells through that vault while active. The contract caps each wallet restriction at 168 hours, permits only one activation per wallet, and automatically reopens transfers at expiry. Extension and early reopening are not supported. Designated admin liquidity deposits are exempt. Admin targeting is not restricted on-chain to DeDust vaults; metadata remains admin-updatable. This restriction does not lock LP tokens."
+image: "https://raw.githubusercontent.com/younissafa5555-maker/vulmo-assets/main/vulmo-vlo.jpg"
+address: EQDQd8MFPbNGzL1mtgS88P19-36o0-KiQhzWMOzoB061JPg6
+symbol: VLO
+decimals: 9


### PR DESCRIPTION
Add VULMO (VLO) to the jetton registry. Only jettons/VLO.yaml is changed.

Token details:
- Network: TON mainnet
- Jetton master: EQDQd8MFPbNGzL1mtgS88P19-36o0-KiQhzWMOzoB061JPg6
- Decimals: 9
- Total supply at the last check: 120,000,000 VLO
- Latest get_jetton_data result: mintable=false.
- DeDust pool: EQAA-VsPqOZAhKChpnYhqX7NsAxdiJvue53ixDBgQ74y_NqY
- Reserves at the last check: 150 TON and 9,000,000 VLO.
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/vulmo-assets/main/vulmo-vlo.json
- Logo: https://raw.githubusercontent.com/younissafa5555-maker/vulmo-assets/main/vulmo-vlo.jpg

Transparency note:
The jetton-wallet contract includes an admin-activated incoming-transfer restriction. At the last getter check, sell control was disabled on both the DeDust vault jetton wallet and the admin jetton wallet. A 167-hour restriction is planned for the DeDust vault jetton wallet EQDbjOenZGf4GxXKBR0g2Dh8iRvFI-btFP9hKfk3Zbe-cebA.

When activated, ordinary incoming transfers to that wallet are rejected, preventing sells through that vault. Ordinary admin transfers are also restricted; only the designated admin liquidity-deposit flow is exempt. This is a transfer restriction, not an LP-token lock.

The contract requires paused=false and a future unlock timestamp no more than 168 hours from activation. The restriction automatically expires at that timestamp and cannot be extended, disabled early, or activated again on the same wallet.

The admin supplies vaultOwner; the contract does not independently limit activation to official DeDust vaults. The one-time limit applies per jetton wallet, not globally. The designated liquidity manager must be the admin. Metadata-update authority remains with the admin.

Local sandbox tests reported passing for lock limits, authorization, inbound rejection, automatic reopening, and rejection of relocking. These tests are not an independent security audit.


Post-activation update:
The planned timed restriction has now been activated and confirmed by the on-chain getter on vault jetton wallet EQDbjOenZGf4GxXKBR0g2Dh8iRvFI-btFP9hKfk3Zbe-cebA.
Confirmed state: enabled=true, paused=false, sellOpen=false, lockedUntil=1789811171.
Automatic unlock: 2026-09-19 09:46:11 UTC. The earlier disabled-state observation above was before activation.
Admin wallet sell control remains disabled. Ordinary admin transfers into the restricted vault are also rejected; only the designated admin liquidity-deposit flow is exempt.
This restriction does not lock LP tokens.
