### PR TITLE
Add ConfaHub Coin (CHC)

### DIFF
--- a/jettons/ConfaHub Coin.yaml
+++ b/jettons/ConfaHub Coin.yaml
@@ -1,0 +1,10 @@
+name: "ConfaHub Coin"
+description: "Официальный токен экосистемы ConfaHub"
+image: "https://confahub.com/static/branding/confahub-egid-token.png"
+address: "EQB9IJbQ2LBEHHHxXJeTvlDzFLxozpKgOsXX5YkxNmwwITwW"
+symbol: "CHC"
+websites:
+  - "https://confahub.com"
+social:
+  - "https://t.me/confahub"
+  - "https://x.com/confahub"

--- a/jettons/ConfaHub Coin.yaml
+++ b/jettons/ConfaHub Coin.yaml
@@ -8,3 +8,4 @@ websites:
 social:
   - "https://t.me/confahub"
   - "https://x.com/confahub"
+  - "https://discord.gg/confahub"


### PR DESCRIPTION
Please review ConfaHub Coin (CHC) for inclusion in TON Assets.

- Jetton master: `EQB9IJbQ2LBEHHHxXJeTvlDzFLxozpKgOsXX5YkxNmwwITwW`
- Explorer: https://tonviewer.com/EQB9IJbQ2LBEHHHxXJeTvlDzFLxozpKgOsXX5YkxNmwwITwW
- Website: https://confahub.com
- Telegram: https://t.me/confahub
- X: https://x.com/confahub
- Direct logo URL: https://confahub.com/static/branding/confahub-egid-token.png

The name, symbol, description and image URL match the current jetton metadata. The logo URL responds with image/png. Only jettons/ConfaHub Coin.yaml is added; generated files are unchanged.

The token currently uses 9 decimals. Additional minting remains enabled; this submission makes no fixed-supply claim.