### PR TITLE
Add LYNEXM (LNM)

### DIFF
--- a/jettons/LNM.yaml
+++ b/jettons/LNM.yaml
@@ -1,0 +1,6 @@
+name: LYNEXM
+description: "LYNEXM (LNM) on TON. Includes an admin-activated incoming-transfer restriction, planned for 167 hours on the DeDust vault jetton wallet, preventing ordinary sells through that vault while active. Each wallet restriction is capped on-chain at 168 hours, can be activated only once, and automatically expires. Extension and early reopening are not supported. Transfers from the designated admin liquidity manager carrying the DeDust liquidity-deposit opcode are exempt; the wallet does not verify successful liquidity provision. Admin targeting is not restricted on-chain to official DeDust vaults. Metadata remains admin-updatable. This restriction does not lock LP tokens."
+image: "https://raw.githubusercontent.com/younissafa5555-maker/lynexm-assets/main/lynexm-lnm.jpg"
+address: EQDWb_Vv2ECCCiD8OYmGz5gKrq1Rv9n2fafRJkwtiKlFuQ9j
+symbol: LNM
+decimals: 9


### PR DESCRIPTION
Add LYNEXM (LNM) to the jetton registry. Only jettons/LNM.yaml is changed.

Token details:
- Network: TON mainnet
- Jetton master: EQDWb_Vv2ECCCiD8OYmGz5gKrq1Rv9n2fafRJkwtiKlFuQ9j
- Decimals: 9
- Total supply at the last getter check: 120,000,000 LNM
- Mintable: false. Minting is permanently closed; holders can still burn tokens.
- DeDust pool: EQAvvBAyovP_ODCEVqkFwM80IIuHecrjiIzNoDRQca1heD7X
- Reserves at the last check: 200 TON and 900,000 LNM.
- Metadata: https://raw.githubusercontent.com/younissafa5555-maker/lynexm-assets/main/lynexm-lnm.json
- Logo: https://raw.githubusercontent.com/younissafa5555-maker/lynexm-assets/main/lynexm-lnm.jpg

Transparency note:
The wallet contract includes an admin-activated incoming-transfer restriction. At the last getter check it was disabled on both the vault jetton wallet and the admin jetton wallet. A 167-hour restriction is planned for vault jetton wallet EQB0uI2NyL4vvbjrqZilhAkK6SbCxlTiv4icKP_G03obKaUL.

While active, ordinary incoming transfers to the target wallet are rejected, preventing ordinary sells through that vault. This incoming-transfer restriction does not itself block outgoing transfers from the vault. Ordinary admin transfers into the target are also restricted. Transfers from the designated admin liquidity manager carrying the DeDust liquidity-deposit opcode are exempt; the wallet does not verify successful liquidity provision.

Activation requires enabled=true, paused=false and a future unlock timestamp no more than 168 hours away. Transfers automatically reopen at expiry. The restriction cannot be extended, disabled early or activated again on the same wallet.

The admin supplies vaultOwner. On-chain targeting is not limited to official DeDust vaults, and the one-time limit applies per wallet rather than globally. The liquidity manager must be the admin. Metadata remains admin-updatable. This restriction does not lock LP tokens.

Local sandbox tests passed for duration limits, authorization, rejection of extension and early disable, ordinary inbound rejection, automatic reopening and rejection of relocking. These tests are not an independent security audit.


Post-activation update:
The planned timed restriction has been activated. The supplied on-chain getter output confirms vault jetton wallet EQB0uI2NyL4vvbjrqZilhAkK6SbCxlTiv4icKP_G03obKaUL has enabled=true, paused=false, sellOpen=false and lockedUntil=1789842013.
Automatic unlock: 2026-09-19 18:20:13 UTC. The disabled-state observation above was before activation.
Admin wallet sell control remains disabled. Ordinary admin transfers into the restricted vault are also rejected. The exemption checks the admin liquidity-manager sender and DeDust liquidity-deposit opcode; successful liquidity provision is not verified by the wallet.
This restriction does not lock LP tokens.
